### PR TITLE
Issue#14 cli documentation removal

### DIFF
--- a/concepts.rst
+++ b/concepts.rst
@@ -46,12 +46,12 @@ The easiest way to manage your storage with Rockstor is via it's web-ui. It can
 be accessed by visiting the appliance's management IP over https using the
 Firefox browser. Note that other browsers are not supported.
 
-CLI
----
+Secure Shell
+------------
 
 Console access to Rockstor is possible by logging in as one of the admin users
-using SSH. Rockstor CLI is userfriendly with help and examples available on all
-commands. CLI can also be used to perform operations non-interactively.
+using SSH.  During normal operations this should not be required but is
+provided for advanced configurations and development purposes.
 
 Smart Manager
 -------------

--- a/concepts.rst
+++ b/concepts.rst
@@ -6,11 +6,14 @@ Disk
 ----
 
 A disk is a block device that is usable by Rockstor. Disks can be locally
-attached SCSI or SATA drives or can be SAN backed block devices.
+attached SCSI or SATA drives or can be SAN backed block devices, there is also
+increasing support for some virtual block devices for when Rockstor is
+installed in a virtual machine.
 
-Rockstor only works with whole drives and not partitions. If a disk has
-partitions, it is displayed in the list of available disks but is
-unusable. Parition table can be wiped using the UI and make the disk usable.
+N.B. Rockstor only works with whole drives and not partitions. If a disk has
+partitions it is displayed in the list of available disks but is
+unusable. However the UI does provide a facility to remove any existing
+partition tables so that those disks might become usable.
 
 Disks can be added online as long as it is supported by the underlying
 hardware. Rockstor can rescan to detect new disks and make them available.

--- a/features.rst
+++ b/features.rst
@@ -25,23 +25,6 @@ explanation.
 
 * Manage other Rockstor appliances by quick switching.
 
-User friendly CLI
------------------
-
-Rockstor CLI is designed to provide every necessary command without
-overwhelming the user. All commands have documentation and examples. Below are
-the feature highlights. See :ref:`cli` for a more detailed explanation.
-
-* Secure access via SSH
-
-* Switch to specific consoles of subsystems like pools, shares, nfs, network
-  etc.. for a clean user experience.
-
-* Automate using CLI batch mode from any language including Shell, Perl and
-  Python.
-
-* Retrieve commands from history.
-
 Online disk management
 ----------------------
 
@@ -113,7 +96,6 @@ workloads. The following probes are available
 * Call metadata with specific uid and gid information.
 
 See :ref:`analytics` for more details.
-
 
 Support
 -------

--- a/features.rst
+++ b/features.rst
@@ -37,7 +37,7 @@ Online disk management
   without unnecessary disruption.
 
 Online Pool management
------------------------
+----------------------
 
 * Create pools instantly using the web-ui or CLI.
 

--- a/intro.rst
+++ b/intro.rst
@@ -53,7 +53,7 @@ for clarity.
 +-----------------------------+---------+--------------------------------+
 | WebDAV                      | planned |                                |
 +-----------------------------+---------+--------------------------------+
-| FTP/SFTP                    | planned |                                |
+| SFTP                        | beta    |                                |
 +-----------------------------+---------+--------------------------------+
 | Asynchronous share          | beta    | replicate shares between       |
 | replication                 |         | multiple Rockstor appliances   |

--- a/intro.rst
+++ b/intro.rst
@@ -61,7 +61,7 @@ for clarity.
 | WebUI                       | prod    | efficient management through   |
 |                             |         | Firefox browser                |
 +-----------------------------+---------+--------------------------------+
-| CLI                         | beta    |                                |
+| SSH                         | prod    | standard bash shell            |
 +-----------------------------+---------+--------------------------------+
 | RESTful API                 | prod    | integrate applications with    |
 |                             |         | Rockstor                       |

--- a/uis.rst
+++ b/uis.rst
@@ -1,12 +1,10 @@
 
 User Interfaces
 ===============
-RockStor supports multiple ways for a user to interact
-with the appliance. It supports operations through 
+Rockstor supports 2 main user interface methods.
 
 1. a browser based interface (web-ui)
-2. a command line interface (CLI) that can be used for scripting common operations, 
-3. a RESTful API that enables complete programmatic control of the appliance.
+2. a RESTful API that enables complete programmatic control
 
 .. _webui:
 
@@ -17,17 +15,16 @@ The RockStor browser based interface or web-ui is supported on the Firefox
 web browser.
 
 The initial setup of the appliance should be done through the
-web-ui, and once it is completed, any of the supported interfaces can be used
-to interact with it.
+web-ui, and once it is completed, any interface method can be used; including ssh bash access if required.
 
 .. _setup:
 
 Setup
 ^^^^^
 
-Once RockStor installation is finished as described in the
+Once Rockstor installation is finished, as described in the
 :ref:`installation` section, the new appliance can be setup by visiting
-https://<appliance_ip> using the Firefox browser.
+https://<appliance_ip> in your browser.
 
 The setup process consists of two screens. In the first screen, an admin user
 must be created by entering desired credentials. In the second screen, all
@@ -40,27 +37,6 @@ process as shown below.
 
 Once the setup process is complete, the newly created admin user is logged in
 and the Rockstor dashboard is displayed.
-
-.. _cli:
-
-CLI
----
-
-RockStor provides a command line interface that can be used by a user to
-administer the appliance, or used for scripting to automate repetitive
-tasks.
-
-To access the CLI, ssh to the appliance as an admin user. The CLI is structured
-as a collection of subconsoles and the user is placed in the main console.
-
-At any point in the CLI, entering 'help' or '?' prints a list of available
-commands.
-
-.. image:: cli.png
-   :align: center
-
-The subsections and commands will be further explained in the corresponding
-sections of the documentation that they are related to.
 
 .. _api:
 


### PR DESCRIPTION
Removes all references to CLI function and in some cases replaces it with mention of SSH.
Note there are a few minor non CLI related changes here, most notably with reference to virtual block devices in "Basic Concepts", sorry they crept in as I was there.
Also note the removal of FTP, replaced with SFTP only and its status change from planned to beta.
Hope that all OK.

Tested as before with "make html" using Sphinx v1.2.3
No errors except for the usual first build warning on missing _static

