### PR TITLE
Issue#64 sphinx and subdirectories

### DIFF
--- a/themes/rockstor/layout.html
+++ b/themes/rockstor/layout.html
@@ -49,7 +49,8 @@
                 <span class="icon-bar"></span>
                 <span class="icon-bar"></span>
             </button>
-            <a href="/"><img src="_static/img/rockstorlogo-font2.png" style="padding-top: 8px;" width="150px">
+            <!--<a href="/"><img src="_static/img/rockstorlogo-font2.png" style="padding-top: 8px;" width="150px"> -->
+            <a href="/"><img src="{{ pathto('_static/' + 'img/rockstorlogo-font2.png', 1) }}" style="padding-top: 8px;" width="150px">
             </a>
         </div>
 

--- a/themes/rockstor/layout.html
+++ b/themes/rockstor/layout.html
@@ -7,7 +7,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>RockStor: Free and Easy File storage</title>
 <script src="http://use.edgefonts.net/source-sans-pro.js"></script>
-<script src="_static/js/libs/bootstrap.js"></script>
+<script src="{{ pathto('_static/' + 'js/libs/bootstrap.js', 1) }}"></script>
 <script src="https://ajax.googleapis.com/ajax/libs/jquery/2.1.4/jquery.min.js"></script>
 <!--<link rel="shortcut icon" href="_static/img/ico/favicon.ico" type="image/x-icon" />-->
 <link rel="shortcut icon" href="{{ pathto('_static/' + 'img/ico/favicon.ico', 1) }}" type="image/x-icon" />

--- a/themes/rockstor/layout.html
+++ b/themes/rockstor/layout.html
@@ -9,7 +9,8 @@
 <script src="http://use.edgefonts.net/source-sans-pro.js"></script>
 <script src="_static/js/libs/bootstrap.js"></script>
 <script src="https://ajax.googleapis.com/ajax/libs/jquery/2.1.4/jquery.min.js"></script>
-<link rel="shortcut icon" href="_static/img/ico/favicon.ico" type="image/x-icon" />
+<!--<link rel="shortcut icon" href="_static/img/ico/favicon.ico" type="image/x-icon" />-->
+<link rel="shortcut icon" href="{{ pathto('_static/' + 'img/ico/favicon.ico', 1) }}" type="image/x-icon" />
 
 
     <script>

--- a/themes/rockstor/layout.html
+++ b/themes/rockstor/layout.html
@@ -9,7 +9,6 @@
 <script src="http://use.edgefonts.net/source-sans-pro.js"></script>
 <script src="{{ pathto('_static/' + 'js/libs/bootstrap.js', 1) }}"></script>
 <script src="https://ajax.googleapis.com/ajax/libs/jquery/2.1.4/jquery.min.js"></script>
-<!--<link rel="shortcut icon" href="_static/img/ico/favicon.ico" type="image/x-icon" />-->
 <link rel="shortcut icon" href="{{ pathto('_static/' + 'img/ico/favicon.ico', 1) }}" type="image/x-icon" />
 
 
@@ -50,7 +49,6 @@
                 <span class="icon-bar"></span>
                 <span class="icon-bar"></span>
             </button>
-            <!--<a href="/"><img src="_static/img/rockstorlogo-font2.png" style="padding-top: 8px;" width="150px"> -->
             <a href="/"><img src="{{ pathto('_static/' + 'img/rockstorlogo-font2.png', 1) }}" style="padding-top: 8px;" width="150px">
             </a>
         </div>


### PR DESCRIPTION
As far as the main logo not appearing and also the favicon not appearing when viewing sub directory stored sections, ie rockons and reinstall, this patch sorts these locally.
Sphinx v1.2.3 seems as happy as usual.
However I am unsure of the knockons of the dynamic path to bootstrap.js.
Added to attempt fix on community js dropdown menu which I think should now work.
This was also affected by sections stored in subdirectories (as in broken by them).
Looks good to me though.
fixes #64 