### PR TITLE
issue#49_fix broken search on subdir pages with pathto

### DIFF
--- a/themes/rockstor/layout.html
+++ b/themes/rockstor/layout.html
@@ -92,7 +92,7 @@
         <span style="padding-left: 20px;" class="h1">Documentation</span>
 
         <div class="pull-right">
-            <form class="form-inline" id="top-search" method="get" action="search.html">
+            <form class="form-inline" id="top-search" method="get" action="{{ pathto('search.html', 1) }}">
                 <input type="text" value="" name="q"></input>
                 &nbsp;
                 <input class="btn btn-primary-main-story" type="submit" value="Search"></input>


### PR DESCRIPTION
Yet another pathto fix in theme, this time on the generated search.html
N.B. The search feature can only be tested locally on Firefox as Chrome has additional cross origin protection of sorts.
Works for me in Firefox (and assuming it will in Chrome when deployed) for both hit and miss searches
ie "features" and "test2" on both top level and subdir pages.
fixes #49 

