### PR TITLE
add unetbootin note plus misc improvements Fixes #81

### DIFF
--- a/clients.rst
+++ b/clients.rst
@@ -20,10 +20,10 @@ as described below.
 Unix/Linux
 ^^^^^^^^^^
 
-   On a Unix/Linux client, the RockStor server will appear in the
-   File explorer application as an entry of the form **RockStor@<ip-address>** under **Browse Network** . Clicking on the server will display the available exported shares that have Browseable true.
+   On a Unix/Linux client, the Rockstor server will appear in the
+   File explorer application as an entry of the form **Rockstor@<ip-address>** under **Browse Network** . Clicking on the server will display the available exported shares that have Browseable true.
 
-   If the RockStor server does not appear in the File explorer, a connection can be made by selecting 'Connect to Server'
+   If the Rockstor server does not appear in the File explorer, a connection can be made by selecting 'Connect to Server'
 
    .. image:: smb_linux_network.png
       :scale: 65%
@@ -43,7 +43,7 @@ Windows
 Mac OS
 ^^^^^^
 
-   On a Mac OS, the RockStor server will appear in the Finder sidebar, as an entry of the form **RockStor@<ip-address>**. Connecting to the server can be done by clicking on the entry, and authenticating as a specific user who has permissions to access the share, (or as a guest user, if the share has Guest OK set to true) as shown below.
+   On a Mac OS, the Rockstor server will appear in the Finder sidebar, as an entry of the form **Rockstor@<ip-address>**. Connecting to the server can be done by clicking on the entry, and authenticating as a specific user who has permissions to access the share, (or as a guest user, if the share has Guest OK set to true) as shown below.
 
    .. image:: smb_mac_auth.png
       :scale: 65%

--- a/conf.py
+++ b/conf.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# RockStor documentation build configuration file, created by
+# Rockstor documentation build configuration file, created by
 # sphinx-quickstart on Thu Oct 17 09:09:17 2013.
 #
 # This file is execfile()d with the current directory set to its

--- a/contribute.rst
+++ b/contribute.rst
@@ -162,7 +162,7 @@ Build VM
 --------
 
 You need a Virtual Machine (VM) to build and test your changes. An easy
-solution is to create a RockStor VM using either Oracle's `VirtualBox
+solution is to create a Rockstor VM using either Oracle's `VirtualBox
 <https://www.virtualbox.org/>`_ or if you are using a Linux desktop then
 `Virtual Machine Manager <https://virt-manager.org>`_ is also an option. You
 can find a `VirtualBox Rockstor install demo

--- a/contribute.rst
+++ b/contribute.rst
@@ -17,15 +17,21 @@ There is a lot you can do other than coding that is essential to the
 project. First, please join our `community discussion forum
 <http://forum.rockstor.com>`_. It's the central location where all discussions
 take place. If you need help, want to share an idea, suggest a new feature etc..
-the forum is a great place to start. Being active there could be very helpful to
-the project and our community.
+the forum is a great place to start. Being active on the forum is very helpful
+to the project and the community as a whole.
 
 Contributions such as testing and reporting bugs are tremendously helpful and
-greatly appreciated.
+greatly appreciated. Please see our :ref:`update_channels` section and
+specifically the :ref:`testing_channel` sub section for information on how to
+track the latest fixes and features.
 
 You can also contribute to the documentation of the project, which in many
 cases is crucial and often lags behind. So documentation contributions are
 also very much appreciated. For more information go to :ref:`contributedocs`
+
+Finally Rockstor's continued development and distribution depends on all those
+choosing to subscribe to the :ref:`stable_channel` updates where all the
+:ref:`testing_channel` work end up.
 
 .. _developers:
 

--- a/contribute.rst
+++ b/contribute.rst
@@ -1,16 +1,17 @@
 
 .. _contributetorockstor:
 
-Contribute to Rockstor
-======================
+Contributing to Rockstor - Overview
+===================================
 
 Rockstor is free and open source software and we are proud of our budding
-developer and user community. Anyone can contribute in a number of different ways.
+developer and user community. Anyone can contribute in a number of different
+ways.
 
 .. _storageexperts:
 
 Non developers
----------------
+--------------
 
 There is a lot you can do other than coding that is essential to the
 project. First, please join our `community discussion forum
@@ -24,7 +25,7 @@ greatly appreciated.
 
 You can also contribute to the documentation of the project, which in many
 cases is crucial and often lags behind. So documentation contributions are
-appreciated very much. For more information go to :ref:`contributedocs`
+also very much appreciated. For more information go to :ref:`contributedocs`
 
 .. _developers:
 

--- a/contribute_documentation.rst
+++ b/contribute_documentation.rst
@@ -1,7 +1,7 @@
 .. _contributedocs:
 
 Contributing to Rockstor documentation
---------------------------------------
+======================================
 
 Steps for contributing to **rockstor-doc** repo are similar to contributing to
 **rockstor-core**, as we follow the same fork and pull request model. We’ll

--- a/contribute_section.rst
+++ b/contribute_section.rst
@@ -1,0 +1,8 @@
+Community Contributions
+=======================
+
+.. toctree::
+   :maxdepth: 2
+
+   contribute
+   contribute_documentation

--- a/dashboard.rst
+++ b/dashboard.rst
@@ -2,7 +2,7 @@
 Dashboard
 =========
 
-The RockStor dashboard is a view for an admin to rapidly monitor the storage, compute and network resources of the appliance.
+The Rockstor dashboard is a view for an admin to rapidly monitor the storage, compute and network resources of the appliance.
 
 The dashboard is designed as a configurable set of widgets, each displaying
 information about the resources mentioned above. Here are some features of

--- a/faq.rst
+++ b/faq.rst
@@ -6,7 +6,7 @@ Product FAQ
 What is Rockstor?
 -----------------
 
-RockStor is a **free and open source NAS (Network Attached Storage) operating
+Rockstor is a **free and open source NAS (Network Attached Storage) operating
 system**. It's a software solution and can be installed on commodity hardware
 or a hypervisor satisfying :ref:`minsysreqs`
 

--- a/home_nas_guide.rst
+++ b/home_nas_guide.rst
@@ -16,8 +16,8 @@ You need to store all movies, music, photos, documents that you create
 every day, and be able to access them from any computer in your home. 
 
 This guide looks at how to build your own NAS using easily available
-hardware, and the RockStor storage server.
-RockStor is an open-source storage server based on linux, that can be
+hardware, and the Rockstor storage server.
+Rockstor is an open-source storage server based on linux, that can be
 installed on commodity hardware.
 
 Hardware
@@ -53,28 +53,28 @@ Hard drives to hold your data. Multiple hard drives are recommended, to create p
       
 **Software**
       
-Download the RockStor iso at `http://www.rockstor.com/downloads <http://rockstor.com/downloads.html>`_
+Download the Rockstor iso at `http://www.rockstor.com/downloads <http://rockstor.com/downloads.html>`_
 
-If you are using a USB drive as the installation media, prepare the USB drive with the RockStor iso by following `these instructions <https://fedoraproject.org/wiki/How_to_create_and_use_Live_USB>`_
+If you are using a USB drive as the installation media, prepare the USB drive with the Rockstor iso by following `these instructions <https://fedoraproject.org/wiki/How_to_create_and_use_Live_USB>`_
 
 **Installation and Setup**
 
 Insert both the flash drives into the server. Set the flash drive containing the iso as the boot disk, and during installation, select the other flash drive as the destination to install RockStor.
 
-Install RockStor using the installation instructions provided in our :ref:`quickstartguide` Guide
+Install Rockstor using the installation instructions provided in our :ref:`quickstartguide` Guide
 
-**Using RockStor**
+**Using Rockstor**
         
 1. Accessing a shared folder from a Mac client
 
-   To access a shared folder on RockStor from a Mac, you have to create a pool, create a share in the pool, and export it using Samba. This is explained in the :ref:`createshare` section.
+   To access a shared folder on Rockstor from a Mac, you have to create a pool, create a share in the pool, and export it using Samba. This is explained in the :ref:`createshare` section.
 
-   Once you have exported the Share using Samba on RockStor, it should appear as a folder in the Devices menu on your Mac.
+   Once you have exported the Share using Samba on Rockstor, it should appear as a folder in the Devices menu on your Mac.
 
 2. Accessing a shared drive from a Windows client
 
-   To access a shared folder on RockStor from a Mac, you have to create a pool, create a share in the pool, and export it using Samba. This is explained in the :ref:`createshare` section.
+   To access a shared folder on Rockstor from a Mac, you have to create a pool, create a share in the pool, and export it using Samba. This is explained in the :ref:`createshare` section.
 
-   Once you have exported the Share using Samba on RockStor, it should appear as a folder in the Devices menu on your Mac.
+   Once you have exported the Share using Samba on Rockstor, it should appear as a folder in the Devices menu on your Mac.
 
 

--- a/index.rst
+++ b/index.rst
@@ -1,5 +1,5 @@
 
-.. RockStor documentation master file, created by
+.. Rockstor documentation master file, created by
    sphinx-quickstart on Thu Oct 17 09:09:17 2013.
    You can adapt this file completely to your liking, but it should at least
    contain the root `toctree` directive.

--- a/index.rst
+++ b/index.rst
@@ -38,7 +38,7 @@ Welcome to Rockstor
    ups-setup/ups_setup
    clients
    support
-   contribute
+   contribute_section
    howtos
    analytics
    benchmarks

--- a/install.rst
+++ b/install.rst
@@ -34,8 +34,8 @@ that are known to work with Rockstor. Below is a list of these recommendations.
 Complete Builds for Home and small organizations
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-1. `This <http://rockstor.com/blog/uncategorized/8tb-rockstor-diy-nas>`_ is one
-   of the first builds assembled by Rockstor developers and works great. It is
+1. This is `one of the first <http://rockstor.com/blog/uncategorized/8tb-rockstor-diy-nas>`_
+   builds assembled by Rockstor developers and works great. It is
    a production server of Rockstor team for several purposes. You can get a
    `boot drive
    <http://shop.rockstor.com/collections/diy-accessories/products/pcie-msata-boot-drive>`_
@@ -66,10 +66,10 @@ The following are off the shelf products that require very little DIY work, if
 any. They provide USB 3.0, making it convenient to use external USB drives with
 impressive speeds.
 
-1. Intel NUC. To find out more, read this `blog post
+1. Intel NUC. To find out more, see `Garrett's blog post
    <http://rockstor.com/blog/tutorials/rockstor-on-the-intel-nuc/>`_.
 
-2. ASUS VivoPC. To find out more, read this `blog post
+2. ASUS VivoPC. To find out more, see `Amir's blog post
    <http://rockstor.com/blog/personal-cloud/rockstor-on-asus-vivopc/>`_.
 
 

--- a/intro.rst
+++ b/intro.rst
@@ -15,6 +15,7 @@ into a private cloud server.
 Rockstor can be installed on commodity hardware or as a virtual machine on
 hypervisors like Xen, KVM and VMWare.
 
+.. _featurestable:
 
 Features
 --------

--- a/pools-btrfs.rst
+++ b/pools-btrfs.rst
@@ -83,9 +83,11 @@ level. Instead, selectively enable it on Shares.
 
 Besides not enabling compression at all, there are two additional choices
 
-* **zlib**: Provies slower but higher compression ratio. You can find out more `here <http://www.zlib.net/manual.html>`_.
+* **zlib**: Provides slower but higher compression ratio. You can find out
+  more from `zlib.net <http://www.zlib.net/manual.html>`_.
 * **lzo**: A faster compression algorithm but provides lower ratio compared to
-  **zlib**. You can find out more `here <http://www.oberhumer.com/opensource/lzo/>`_.
+  **zlib**. You can find out more from `oberhumer.com
+  <http://www.oberhumer.com/opensource/lzo/>`_.
 
 
 Mount Options
@@ -94,7 +96,7 @@ Mount Options
 These are optional and meant for more advanced users to provide BTRFS specific
 mount options. Since a Pool is a filesystem, it is mounted with default options
 which can be altered by providing one or more of the following. You can find
-out more about each option `here
+out more about each option from the `btrfs wiki mount options section
 <https://btrfs.wiki.kernel.org/index.php/Mount_options>`_.
 
 * **alloc_start**
@@ -116,8 +118,6 @@ out more about each option `here
 * **ssd**
 * **ssd_spread**
 * **thread_pool**
-
-|
 
 .. _poolresize:
 
@@ -195,7 +195,7 @@ Scrubbing a Pool
 
 The scrub operation initiates a BTRFS scrub process in the background. It reads
 all data from all disks of the Pool, verifies checksums and fixes corruptions
-if detected and possible. To find out more, go `here
+if detected and possible. To find out more, see the `btrfs wiki scrub section
 <https://btrfs.wiki.kernel.org/index.php/Manpage/btrfs-scrub>`_.
 
 To start a scrub, go to the Pool's detail page and click on the **Start a new
@@ -216,7 +216,8 @@ The balance operation initiates a BTRFS balance process in the background. It
 spreads data more evenly across multiple disks of the Pool. It is automatically
 triggered after a :ref:`poolresize` operation, which is the main purpose of
 this feature. A standalone balance operation is intended for advanced users who
-can judge for themselves if it is necessary. To find out more, go `here
+can judge for themselves if it is necessary. To find out more, see the `btrfs
+wiki balance section
 <https://btrfs.wiki.kernel.org/index.php/FAQ#What_does_.22balance.22_do.3F>`_.
 
 To start a balance, go to the Pool's detail page and click on the **Start a new

--- a/quickstart.rst
+++ b/quickstart.rst
@@ -18,7 +18,7 @@ recommendations.
 * 8GB hard disk space for the OS
 * One or more additional hard drives for data (recommended)
 * Ethernet interface (with internet access -- for updates)
-* a UPS (if desired) that is supported by `nut <http://www.networkupstools.org/>`_
+* a UPS (if desired) that is supported by `NUT <http://www.networkupstools.org/>`_
 * CD/DVD drive or USB port for installation
 
 Download Rockstor

--- a/quickstart.rst
+++ b/quickstart.rst
@@ -71,7 +71,7 @@ about installation.
 .. raw:: html
 
    <div class="alert alert-warning">
-   <strong>Important!</strong> Installing RockStor deletes existing data on the system
+   <strong>Important!</strong> Installing Rockstor deletes existing data on the system
    drive(s) selected as installation destination.
    </div>
 
@@ -110,7 +110,7 @@ about installation.
     .. raw:: html
 
         <div class="alert alert-warning">
-        <strong>Important!</strong> Installing RockStor deletes existing data on the system
+        <strong>Important!</strong> Installing Rockstor deletes existing data on the system
         drive(s) selected as installation destination.
         </div>
 

--- a/quickstart.rst
+++ b/quickstart.rst
@@ -25,8 +25,8 @@ Download Rockstor
 -----------------
 
 Rockstor `download options <http://rockstor.com/download.html>`_. Create a
-bootable CD or USB drive from the downloaded iso and proceed to the next
-section for installation.
+bootable CD or USB drive from the downloaded iso and proceed to the
+:ref:`installation` section.
 
 .. raw:: html
 
@@ -35,15 +35,23 @@ section for installation.
    Thanks for your support!
    </div>
 
-To create a USB install disk, you can use the dd command on Linux or Mac. For
-example, if your USB drive is /dev/sdc, the command would be::
+.. _makeusbinstalldisk:
 
-  dd if=Rockstor-3.8-0.iso of=/dev/sdc
+Making a Rockstor USB install disk
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+To create a USB install disk on Linux or Mac one can use the dd command. For
+example if your USB device is /dev/sdc then from within the directory
+containing your downloaded Rockstor iso file the command would be:-
+
+  dd if=Rockstor-3.8-9.iso of=/dev/sdc
+
+Note that the .iso file name will vary depending on the Rockstor version.
 
 If you are on Windows, you can use `dd for Windows <http://www.chrysocome.net/dd>`_ or `Rawrite32 <http://www.netbsd.org/~martin/rawrite32/>`_.
 
 **Please note** the following USB image writing programs have been found to
-produce **NON working USB install disks** when used with Rockstor.
+produce **NON working USB install disks** when used with the Rockstor iso file.
 
 * Unetbootin
 * Rufus

--- a/quickstart.rst
+++ b/quickstart.rst
@@ -42,6 +42,12 @@ example, if your USB drive is /dev/sdc, the command would be::
 
 If you are on Windows, you can use `dd for Windows <http://www.chrysocome.net/dd>`_ or `Rawrite32 <http://www.netbsd.org/~martin/rawrite32/>`_.
 
+**Please note** the following USB image writing programs have been found to
+produce **NON working USB install disks** when used with Rockstor.
+
+* Unetbootin
+* Rufus
+
 .. _osinstall:
 
 Installation

--- a/quickstart.rst
+++ b/quickstart.rst
@@ -44,9 +44,20 @@ To create a USB install disk on Linux or Mac one can use the dd command. For
 example if your USB device is /dev/sdc then from within the directory
 containing your downloaded Rockstor iso file the command would be:-
 
-  dd if=Rockstor-3.8-9.iso of=/dev/sdc
+    dd if=Rockstor-3.8-9.iso of=/dev/sdc
 
 Note that the .iso file name will vary depending on the Rockstor version.
+
+Another option on linux systems is the ddrescue command which gives
+more reassuring feedback whilst the USB key is being written. On Debian and
+Ubuntu systems install via *sudo apt-get install gddrescue* and on Fedora
+systems install via *sudo dnf install ddrescue*. Use similarly to dd above
+only using the following command:-
+
+    sudo ddrescue -d -D --force Rockstor-3.8-9.iso /dev/sdc
+
+Note that there are 2 "-" characters next to each other before the "force"
+switch.
 
 If you are on Windows, you can use `dd for Windows <http://www.chrysocome.net/dd>`_ or `Rawrite32 <http://www.netbsd.org/~martin/rawrite32/>`_.
 

--- a/quickstart.rst
+++ b/quickstart.rst
@@ -36,9 +36,9 @@ section for installation.
    </div>
 
 To create a USB install disk, you can use the dd command on Linux or Mac. For
-example, if your USB drive is /dev/sdb, the command would be::
+example, if your USB drive is /dev/sdc, the command would be::
 
-  dd if=Rockstor-3.8-0.iso of=/dev/sdb
+  dd if=Rockstor-3.8-0.iso of=/dev/sdc
 
 If you are on Windows, you can use `dd for Windows <http://www.chrysocome.net/dd>`_ or `Rawrite32 <http://www.netbsd.org/~martin/rawrite32/>`_.
 

--- a/quickstart.rst
+++ b/quickstart.rst
@@ -56,6 +56,10 @@ produce **NON working USB install disks** when used with the Rockstor iso file.
 * Unetbootin
 * Rufus
 
+Please also see the :ref:`usbinstall` and the :ref:`bootorderchanges` sections
+of the :ref:`sohoguide` document for more information on making and using the
+USB install disk.
+
 .. _osinstall:
 
 Installation

--- a/samba_ops.rst
+++ b/samba_ops.rst
@@ -66,7 +66,7 @@ How to Access a share
 From a Windows machine:
 ---------------------------
 
-1. Go to the File explorer and in the location field, enter the ip address of your RockStor appliance in the following format.
+1. Go to the File explorer and in the location field, enter the ip address of your Rockstor appliance in the following format.
 
     * \\\\192.168.1.21
 
@@ -78,18 +78,18 @@ From a Windows machine:
 
 5. Check remember credentials, and click Ok
 
-6. The File explorer will attempt to connect to the RockStor appliance, and if successful, you will be able to see the shares available on RockStor.
+6. The File explorer will attempt to connect to the Rockstor appliance, and if successful, you will be able to see the shares available on Rockstor.
 
 7. To access a share, double click on it.
 
 From a Linux machine:
 --------------------------
 
-1. Open File Browser -> File -> Connect to Server and enter the address of the RockStor appliance in this format.
+1. Open File Browser -> File -> Connect to Server and enter the address of the Rockstor appliance in this format.
 
     * smb://192.168.1.21
 
-2. Click Connect, and you will see the shares available on the RockStor appliance.
+2. Click Connect, and you will see the shares available on the Rockstor appliance.
 
 3. To access a share, double click on it, and you will be presented with a window with Username, Domain, and Password fields. Enter the following
 
@@ -109,11 +109,11 @@ From a Mac:
 
 1. On your Mac, open the Finder, and select *Go* -> *Connect to Server*
 
-2. In the Server address field, type in the address of the shared folder as shown below (with the ip address of your RockStor appliance)
+2. In the Server address field, type in the address of the shared folder as shown below (with the ip address of your Rockstor appliance)
 
    * smb://192.168.1.21/sharename
 
-3. Click Connect. The Finder will connect to the RockStor appliance, and will popup an authentication dialog.
+3. Click Connect. The Finder will connect to the Rockstor appliance, and will popup an authentication dialog.
 
 4. Enter the username and password of a user who has permission to access the share. Select *Remember this password in my keychain*, if you want the connection to be stored, and click *Connect*
 

--- a/shares-btrfs-subvolumes.rst
+++ b/shares-btrfs-subvolumes.rst
@@ -5,7 +5,7 @@ Shares
 
 A Share is a chunk of space carved out of a Pool. Shares behave like
 directories on the Rockstor system which can be accessed via protocols like
-:ref:`samba`, :ref:`afp`, :ref:`nfs` and :ref:`sftp`. They also provide storage
+:ref:`samba`, *afp*, :ref:`nfs` and *sftp*. They also provide storage
 to Rock-ons for application and user generated data. See :ref:`rockons_intro`
 for more information.
 

--- a/soho.rst
+++ b/soho.rst
@@ -15,7 +15,7 @@ are some simple but important uses of such a server.
 3. Create and organize a central repository of all data.
 
 There are more complex usecases which are covered in their own separate
-documents. In this document, We'll describe how to setup RockStor as your
+documents. In this document, We'll describe how to setup Rockstor as your
 centralized storage server, also called a Fileserver or NAS.
 
 .. _serverreqs:
@@ -23,19 +23,19 @@ centralized storage server, also called a Fileserver or NAS.
 Server requirements and suggestions
 -------------------------------------
 
-The first step in building the RockStor Fileserver is to procure
-hardware. Since RockStor is a `Free software
+The first step in building the Rockstor Fileserver is to procure
+hardware. Since Rockstor is a `Free software
 <http://en.wikipedia.org/wiki/Free_software>`_ product based on Linux, there is
 a lot of flexibility. You can purchase hardware that fits your budget and
 performance requirements. See :ref:`minsysreqs` for general guidance. You can
-easily convert an old PC into a Fileserver with RockStor as long
+easily convert an old PC into a Fileserver with Rockstor as long
 as it meets these requirements. You can also purchase small office servers from
 various places like newegg, ebay and Dell.
 
-In our community, RockStor is humming on different hardware. Here are some
+In our community, Rockstor is humming on different hardware. Here are some
 examples:
 
-**Disclaimer: RockStor is a software only product. We don't recommend or
+**Disclaimer: Rockstor is a software only product. We don't recommend or
 certify any particular hardware. These are mere suggestions based on known deployments in our community**
 
 * `HP Proliant Microserver <http://www8.hp.com/us/en/products/proliant-servers/product-detail.html?oid=5379860#!tab=features">`_ is chosen for its small form factor, 4 easily accessible hard drive slots, and eSata capability to expand storage. This is ideal for a simple setup with a small footprint that meets most file storage needs of a small or home office.
@@ -49,13 +49,13 @@ certify any particular hardware. These are mere suggestions based on known deplo
 Hard disk drives
 ----------------
 
-Disk drives are critical in a fileserver. While RockStor offers slick
+Disk drives are critical in a fileserver. While Rockstor offers slick
 management and access to your data, all of it is ultimately stored inside the
 Hard disk drives of the system. Most servers including the ones mentioned in
 :ref:`serverreqs` are compatible with standard SATA HDDs. Once you choose the
 right server based on your needs, choose appropriate HDDs for that server.
 
-**Note about hardware raid**: RockStor provides BTRFS based software RAID
+**Note about hardware raid**: Rockstor provides BTRFS based software RAID
 capabilities. However, advanced servers offer hardware RAID functionality
 providing additional redundancy. Evaluate your risks and choose appropriately.
 
@@ -69,7 +69,7 @@ for more information about this approach.
 Server Memory
 -------------
 
-At least 2 GB of RAM is required for RockStor to function reasonably. This
+At least 2 GB of RAM is required for Rockstor to function reasonably. This
 should deliver decent performance for about 1 TB of data. If your capacity
 needs are larger, a simple rule of thumb is to add 1 GB
 RAM per 1 TB of extra capacity.
@@ -82,15 +82,15 @@ Here's what you need before proceeding with installation
 1. Right server for your needs. See :ref:`serverreqs` for help.
 2. At least two HDDs installed in the system. See :ref:`hdds` for more details.
 3. At least 2 GB of RAM. See :ref:`servermemory` for more information.
-4. (Optional) 8 GB USB drive if you choose to run RockStor entirely from a USB
+4. (Optional) 8 GB USB drive if you choose to run Rockstor entirely from a USB
    flash drive. See :ref:`usboverhdd` for more information.
-5. Network cable to connect the server to your router. RockStor install needs
+5. Network cable to connect the server to your router. Rockstor install needs
    connection to the internet.
 6. CD/DVD ROM drive. If your server does not have an internal CD/DVD ROM, an
    external usb based one should work.
 7. (Optional) 1 GB USB drive if you choose to install from the USB instead of
    CD/DVD ROM.
-8. The RockStor ISO file, downloadable from
+8. The Rockstor ISO file, downloadable from
    `http://rockstor.com/downloads. <http://rockstor.com/downloads.html>`_
 9. A blank CD-R/RW to burn the ISO file to. This is not necessary if installing
    from a USB flash drive as mentioned in step 7.
@@ -98,39 +98,39 @@ Here's what you need before proceeding with installation
 
 .. _cdinstall:
 
-Install RockStor from CD/DVD drive
+Install Rockstor from CD/DVD drive
 ----------------------------------
 
 **Skip this section and go to** :ref:`usbinstall` **instead, if you plan to
-install RockStor from a USB flash drive.**
+install Rockstor from a USB flash drive.**
 
-Installing RockStor from a CD-R/RW is straight forward on most system that
-come with a CD/DVD drive and if there is no built in drive then RockStor
+Installing Rockstor from a CD-R/RW is straight forward on most system that
+come with a CD/DVD drive and if there is no built in drive then Rockstor
 should also install just fine using an external USB CD/DVD drive.
 
-Burn the downloaded RockStor ISO file onto a blank CD or DVD disk as a bootable
+Burn the downloaded Rockstor ISO file onto a blank CD or DVD disk as a bootable
 image. On Linux, you can use programs like K3b. On Windows, you can use Windows
 Disc Image Burner(Windows 7 only) or an open source program like `Infra Recorder.
 <http://infrarecorder.org/>`_ On Mac, use the **Disk Utility** program.
 
-Once the disk is ready to be booted, insert it in your soon to be RockStor
+Once the disk is ready to be booted, insert it in your soon to be Rockstor
 Fileserver and start the machine. Please see :ref:`bootorderchanges`
 to boot the install media.
 
 .. _usbinstall:
 
-Install RockStor from USB flash drive
+Install Rockstor from USB flash drive
 -------------------------------------
 
 **Skip this section and go to** :ref:`cdinstall` **instead, if you plan to
-install RockStor from a CD-R/RW**
+install Rockstor from a CD-R/RW**
 
 A USB flash drive of at least 1 GB in size is required. **All data on the USB
 drive will be erased**. So backup your data as needed before proceeding
 further.
 
 On Windows or Fedora operating systems, Liveusb-creator program can be used to
-prepare your USB flash drive with the RockStor ISO file. If you are using the
+prepare your USB flash drive with the Rockstor ISO file. If you are using the
 Windows operating system then liveusb-creator can be download from
 `liveusb-creator. <https://fedorahosted.org/releases/l/i/liveusb-creator/liveusb-creator-3.12.0-setup.exe>`_
 and install it. On Fedora, run the following command::
@@ -142,7 +142,7 @@ flash drive by running the following command::
 
     # dd if=path_to_rockstor_iso of=/dev/<usb_flash_drive>
 
-Plug the USB flash drive into your soon to be RockStor Fileserver and power
+Plug the USB flash drive into your soon to be Rockstor Fileserver and power
 cycle the machine. Please see :ref:`bootorderchanges` to boot the install
 media.
 
@@ -172,7 +172,7 @@ of future install media on subsequent reboots.
 Installation and Setup
 ----------------------
 
-If you want to install RockStor on to one of the Hard Drives in the system,
+If you want to install Rockstor on to one of the Hard Drives in the system,
 just continue with the installation process as described
 in :ref:`quickstartguide`. But if you like to install it on to a USB flash
 drive, just plug in a USB flash drive with at least 8 GB capacity and select it
@@ -181,9 +181,9 @@ pros and cons of this approach, see :ref:`usboverhdd`
 
 **Note: This USB flash drive is separate and not to be confused with the one
 mentioned earlier in the document. The earlier one can be as little as 1 GB and
-contains the RockStor installer. After the installation, you'll unplug it and
+contains the Rockstor installer. After the installation, you'll unplug it and
 use it again only for another install. This separate drive needs to be at least
-8 GB and will hold the RockStor operating system and must stay plugged
+8 GB and will hold the Rockstor operating system and must stay plugged
 permanently.**
 
 **Note: All data will be completely erased from this USB flash drive. So backup
@@ -191,17 +191,17 @@ your data as needed before proceeding further.**
 
 .. _usboverhdd:
 
-RockStor on USB flash drive
+Rockstor on USB flash drive
 ---------------------------
 
-The RockStor operating system requires a whole Hard disk drive for
+The Rockstor operating system requires a whole Hard disk drive for
 itself. However, it only needs about 8 GB of space to function. This is
 terribly inefficient since the drive capacity is usually in hundreds of
-gigabytes. So, we made it possible to run RockStor completely off a USB flash
+gigabytes. So, we made it possible to run Rockstor completely off a USB flash
 drive as an alternate approach. But as with anything else, there are
 trade-offs.
 
-Here are some advantages of running RockStor completely off a USB flash drive.
+Here are some advantages of running Rockstor completely off a USB flash drive.
 
 1. You save a whole Hard disk drive for data, that would otherwise be claimed
    exclusively by the operating system.
@@ -216,11 +216,11 @@ Here are some disadvantages of this approach
    live on a raid mirror ensuring high availability. This is not possible with
    USB flash drives.
 
-Using RockStor
+Using Rockstor
 --------------
 
 After the installation and initial setup proceses are complete as described in
-:ref:`quickstartguide` and :ref:`setup`, RockStor is ready to be
+:ref:`quickstartguide` and :ref:`setup`, Rockstor is ready to be
 used for all your Fileserver needs.
 
 In order to start storing and accessing your data see :ref:`accessshares`

--- a/soho.rst
+++ b/soho.rst
@@ -1,6 +1,6 @@
 .. _sohoguide:
 
-Small Office Fileserver with RockStor
+Small Office Fileserver with Rockstor
 =====================================
 
 In a small office or home office like environment, a centralized storage server

--- a/soho.rst
+++ b/soho.rst
@@ -111,7 +111,7 @@ Disc Image Burner(Windows 7 only) or an open source program like `Infra Recorder
 
 Once the disk is ready to be booted, insert it in your soon to be RockStor
 Fileserver and start the machine. You may need to change the boot order in BIOS
-to boot from the USB flash drive. This is achieved by booting the system and
+to boot from the CD/DVD drive. This is achieved by booting the system and
 pressing **F12** key on most systems. Soon, the RockStor splash screen should
 appear beginning the installation process.
 

--- a/soho.rst
+++ b/soho.rst
@@ -104,35 +104,35 @@ Install RockStor from CD/DVD drive
 **Skip this section and go to** :ref:`usbinstall` **instead, if you plan to
 install RockStor from a USB flash drive.**
 
+Installing RockStor from a CD-R/RW is straight forward on most system that
+come with a CD/DVD drive and if there is no built in drive then RockStor
+should also install just fine using an external USB CD/DVD drive.
+
 Burn the downloaded RockStor ISO file onto a blank CD or DVD disk as a bootable
 image. On Linux, you can use programs like K3b. On Windows, you can use Windows
 Disc Image Burner(Windows 7 only) or an open source program like `Infra Recorder.
 <http://infrarecorder.org/>`_ On Mac, use the **Disk Utility** program.
 
 Once the disk is ready to be booted, insert it in your soon to be RockStor
-Fileserver and start the machine. You may need to change the boot order in BIOS
-to boot from the CD/DVD drive. This is achieved by booting the system and
-pressing **F12** key on most systems. Soon, the RockStor splash screen should
-appear beginning the installation process.
+Fileserver and start the machine. Please see :ref:`bootorderchanges`
+to boot the install media.
 
 .. _usbinstall:
 
 Install RockStor from USB flash drive
 -------------------------------------
 
-**Skip this section and go to** :ref:`cdinstall` **instead, if you plan to install RockStor from CD-R/RW**
-
-Installing RockStor from a CD-R/RW is straight forward on most servers that
-come with a CD/DVD drive. Even if they don't, RockStor should install smoothly
-using an external usb CD/DVD drive.
+**Skip this section and go to** :ref:`cdinstall` **instead, if you plan to
+install RockStor from a CD-R/RW**
 
 A USB flash drive of at least 1 GB in size is required. **All data on the USB
-drive will be erased**. So backup your data as needed before proceeding further.
+drive will be erased**. So backup your data as needed before proceeding
+further.
 
 On Windows or Fedora operating systems, Liveusb-creator program can be used to
-prepare your USB flash drive with RockStor ISO file. If you are using
-Windows operating system, download the program from
-`here. <https://fedorahosted.org/releases/l/i/liveusb-creator/liveusb-creator-3.12.0-setup.exe>`_
+prepare your USB flash drive with the RockStor ISO file. If you are using the
+Windows operating system then liveusb-creator can be download from
+`liveusb-creator. <https://fedorahosted.org/releases/l/i/liveusb-creator/liveusb-creator-3.12.0-setup.exe>`_
 and install it. On Fedora, run the following command::
 
     # yum install liveusb-creator
@@ -142,11 +142,30 @@ flash drive by running the following command::
 
     # dd if=path_to_rockstor_iso of=/dev/<usb_flash_drive>
 
-Plug the USB flash drive into your soon to be RockStor Fileserver and start the
-machine. You may need to change the boot order in BIOS to boot from the USB
-flash drive. This is achieved by booting the system and pressing **F12** key on
-most systems. Soon, the RockStor splash screen should appear beginning the
-installation process.
+Plug the USB flash drive into your soon to be RockStor Fileserver and power
+cycle the machine. Please see :ref:`bootorderchanges` to boot the install
+media.
+
+..  _bootorderchanges:
+
+Boot order changes
+------------------
+
+When installing Rockstor from a USB boot disk or a CD-R/DVD it may well be
+necessary to change the system's device boot order so that the install disk is
+booted first. Often this can be accomplished by pressing the **F12 key**
+shortly after system power on (note the on screen instructions). If this option
+is not available or doesn't work then try changing the boot options within the
+systems BIOS settings. Take careful note of what you change though so that
+the original setting can be restored if need be. Also note that some systems
+require the USB key to be inserted prior to power on before offering it as an
+option within the BIOS boot section screens.
+
+To get to a systems BIOS (Basic Input / Output System) take note of early
+on screen messages during system power on. Many systems use the **F2 key** or
+the **Del key** and some Compaqs use the **F10** key. Note that changes in the
+system BIOS may have to be un-done post install to prevent accidental booting
+of future install media on subsequent reboots.
 
 .. _installsetup:
 
@@ -180,7 +199,7 @@ itself. However, it only needs about 8 GB of space to function. This is
 terribly inefficient since the drive capacity is usually in hundreds of
 gigabytes. So, we made it possible to run RockStor completely off a USB flash
 drive as an alternate approach. But as with anything else, there are
-tradeoffs.
+trade-offs.
 
 Here are some advantages of running RockStor completely off a USB flash drive.
 
@@ -196,9 +215,6 @@ Here are some disadvantages of this approach
 3. More advanced servers support hardware raid and the operating system can
    live on a raid mirror ensuring high availability. This is not possible with
    USB flash drives.
-
-
-
 
 Using RockStor
 --------------

--- a/soho.rst
+++ b/soho.rst
@@ -114,7 +114,7 @@ Disc Image Burner(Windows 7 only) or an open source program like `Infra Recorder
 <http://infrarecorder.org/>`_ On Mac, use the **Disk Utility** program.
 
 Once the disk is ready to be booted, insert it in your soon to be Rockstor
-Fileserver and start the machine. Please see :ref:`bootorderchanges`
+Fileserver and power cycle the machine. Please see :ref:`bootorderchanges`
 to boot the install media.
 
 .. _usbinstall:

--- a/soho.rst
+++ b/soho.rst
@@ -172,12 +172,12 @@ of future install media on subsequent reboots.
 Installation and Setup
 ----------------------
 
-If you want to install Rockstor on to one of the Hard Drives in the system,
-just continue with the installation process as described
-in :ref:`quickstartguide`. But if you like to install it on to a USB flash
+If you wish to install Rockstor on to one of the Hard Drives / SSD's or mSATA
+devices in the system see our :ref:`quickstartguide` guide and specifically
+the :ref:`osinstall` section. But if you want to install it on to a USB flash
 drive, just plug in a USB flash drive with at least 8 GB capacity and select it
-as the installation destination as described in :ref:`quickstartguide`. For
-pros and cons of this approach, see :ref:`usboverhdd`
+as the installation destination as described in :ref:`quickstartguide`. For the
+pros and cons of this approach see :ref:`usboverhdd`
 
 **Note: This USB flash drive is separate and not to be confused with the one
 mentioned earlier in the document. The earlier one can be as little as 1 GB and

--- a/uis.rst
+++ b/uis.rst
@@ -12,7 +12,7 @@ Rockstor supports two main user interface methods.
 Web-UI
 ------
 
-To access RockStor browser based interface or Web-UI, we recommend using
+To access Rockstor browser based interface or Web-UI, we recommend using
 Firefox or Chrome web browser.
 
 The initial setup of the appliance should be done through the Web-UI, and other

--- a/users.rst
+++ b/users.rst
@@ -3,7 +3,7 @@
 User configuration
 ==================
 
-RockStor supports local user adds, edits and deletes. All local users added by
+Rockstor supports local user adds, edits and deletes. All local users added by
 Rockstor have UIDs starting from 5001. If local users must be added to the
 appliance, ensure that their UIDs are below 5001. Rockstor does not support
 configuration of users that are not added using Rockstor user
@@ -26,7 +26,7 @@ User** button and submit the form to add a new user as shown below.
    :scale: 75 %
    :align: center
 
-If the "``Allow this user to login to RockStor Web UI``" checkbox is unchecked,
+If the "``Allow this user to login to Rockstor Web UI``" checkbox is unchecked,
 the created user will be a local system user but will not be allowed to login
 to the web-ui or CLI. If it is checked, the user can login to the web-ui and CLI.
 


### PR DESCRIPTION
Python 2 version of Sphinx v1.2.3
Compiles without errors and this patch also address all previous Sphinx warnings (bar the usual _static one).

Fixes all issues raised to date in #81.

This patch set also includes additions re links to the new update channels section from contributor sections and various other miscellaneous improvements.
Note that the contributor section has been given a TOC of it's own akin the the HowTo section.
Also note worth is a global search and replace of RockStor with Rockstor; note however that copyright notices were left as is.

All changes have been previewed in both Firefox and Chrome.