### PR TITLE
license rockstor docs as cc-by-sa. Fixes #119

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,0 +1,7 @@
+Vinima Aggarwal
+Suman Chakravartula <schakrava@gmail.com>
+Sujeet Srinivasan <sujeetsr@gmail.com>
+Sheldyn Nam-Storm
+Priyanka Ganti <ganti.priya@gmail.com>
+Philip Guyton <philip@yewtreeapps.com>
+Mazo

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,2 @@
+This work is licensed under the Creative Commons Attribution-ShareAlike 4.0 International License.
+To view a copy of this license, visit http://creativecommons.org/licenses/by-sa/4.0/.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
 rockstor-doc
 ============
 
-For contribution guidelines, see [contributing to docs](http://rockstor.com/docs/contribute.html#contributing-to-the-documentation)
+For contribution guidelines, see [Contributing to Rockstor documentation](http://rockstor.com/docs/contribute_documentation.html)

--- a/contribute.rst
+++ b/contribute.rst
@@ -163,7 +163,8 @@ a fictional example::
         #
 
 If you'd like credit for your patch or if you are a frequent contributor, you
-should add your name to the AUTHORS file.
+should add your name to the `rockstor-core AUTHORS
+<https://github.com/rockstor/rockstor-core/blob/master/AUTHORS>`_ file.
 
 Build VM
 --------

--- a/contribute_documentation.rst
+++ b/contribute_documentation.rst
@@ -93,7 +93,8 @@ a fictional example::
 	#
 
 If you'd like credit for your patch or if you are a frequent contributor, you
-should add your name to the AUTHORS file.
+should add your name to the `rockstor-doc AUTHORS
+<https://github.com/rockstor/rockstor-doc/blob/master/AUTHORS>`_ file.
 
 
 Unlike for code contributions, there is no need for a build VM. We use `Sphinx

--- a/themes/rockstor/layout.html
+++ b/themes/rockstor/layout.html
@@ -134,6 +134,21 @@
             <div class="row-fluid">
                 <div id="footer-links" class="span12 centertext">
                     Copyright &copy; 2015 RockStor, Inc.&nbsp;
+                    <a rel="license"
+                       href="http://creativecommons.org/licenses/by-sa/4.0/"><img
+                        alt="Creative Commons Licence" style="border-width:0"
+                        src="https://i.creativecommons.org/l/by-sa/4.0/88x31.png"/></a><br/><span
+
+                    xmlns:dct="http://purl.org/dc/terms/" property="dct:title">The Official Rockstor Documentation</span>
+                    by <a xmlns:cc="http://creativecommons.org/ns#"
+                          href="https://github.com/rockstor/rockstor-doc/blob/master/AUTHORS"
+                          property="cc:attributionName" rel="cc:attributionURL">various
+                    authors</a> is licensed under a <a rel="license"
+                                                       href="http://creativecommons.org/licenses/by-sa/4.0/">Creative
+                    Commons Attribution-ShareAlike 4.0 International License</a>.<br/>Based
+                    on a work at <a xmlns:dct="http://purl.org/dc/terms/"
+                                    href="https://github.com/rockstor/rockstor-doc"
+                                    rel="dct:source">https://github.com/rockstor/rockstor-doc</a>.
                 </div>
             </div>
             <!-- row-fluid -->


### PR DESCRIPTION
Sphinx v1.2.3 and "make html" generates no errors.
Tested rendering and function with both Chrome an Firefox and all looks OK.

N.B. there are links within the changes that reply on a file that is also added by this patch set (AUTHORS in rockstor-doc) so can't test that but looks fine.

Fixes #119 

Ready for review.