### PR TITLE
add drive serial requirements to min sys spec. Fixes #157

### DIFF
--- a/quickstart.rst
+++ b/quickstart.rst
@@ -22,6 +22,7 @@ recommendations.
 * 8GB hard disk space for the OS
 * One or more additional hard drives for data (recommended)
 * Ethernet interface (with internet access -- for updates)
+* All drives must have unique serial numbers (real drives do); not all VM systems default to this
 * a UPS (if desired) that is supported by `NUT <http://www.networkupstools.org/>`_
 * DVD drive and a blank DVD, or a USB port and min 1 GB USB key (for the installation media)
 


### PR DESCRIPTION
Add a single line to the Quick Start page in the "Minimum system requirements" to indicated the requirement for unique serial numbers with a reference to this pertaining to VM systems not real hw.

Displays as expected in Chrome and Firefox.

Tested using 64bit Sphinx v1.4.8.
No errors indicated.

Fixes #157 

@schakrava Ready for review.