### PR TITLE
address practicality of contributor perk pledge. Fixes #179

### DIFF
--- a/update-channels/update_channels.rst
+++ b/update-channels/update_channels.rst
@@ -125,8 +125,8 @@ subscription for $40.00 USD.
 .. _free_stable:
 
 Please note that any code or documentation contributions to the `Rockstor
-project repositories <https://github.com/rockstor>`_ makes the contributor
-eligible for unlimited Activation codes.
+project repositories <https://github.com/rockstor>`_ makes the
+contributor eligible for up to 10 subscriptions for personal use.
 
 .. _auto_updates:
 


### PR DESCRIPTION
Address impractical contributor perk pledge by explicitly stating intended use.

Please see issue text for details. 

Fixes #179 

@schakrava The changes contained here appear to format correctly in both Chrome and Firefox. But Spinx v1.5.5 (64bit) brought attention to some recent changes to boot_drive_hotwo.rst that are causing errors and warning: as well as formatting issues. Given those issues are unrelated to this change I will address them against their own issue (to be opened shortly).

Ready for review.
 