### PR TITLE
fix highlight css on contribute

### DIFF
--- a/themes/rockstor/static/css/syntax.css
+++ b/themes/rockstor/static/css/syntax.css
@@ -10,7 +10,7 @@
 .highlight .err { color: #960050; background-color: #1e0010 } /* Error */
 .highlight .k { color: #66d9ef } /* Keyword */
 .highlight .l { color: #ae81ff } /* Literal */
-.highlight .n { color: #f8f8f2 } /* Name */
+.highlight .n { color: #000000 } /* Name */
 .highlight .o { color: #f92672 } /* Operator */
 .highlight .p { color: #f8f8f2 } /* Punctuation */
 .highlight .cm { color: #75715e } /* Comment.Multiline */


### PR DESCRIPTION
fix highlights css on contribute page : http://rockstor.com/docs/contribute.html

i changed the css to black because the current color doesn't display in code blocks.
if an other color is preferred please change