### PR TITLE
Issue 176 Added and updated links

### DIFF
--- a/pools-btrfs.rst
+++ b/pools-btrfs.rst
@@ -72,6 +72,9 @@ All standard BTRFS redundancy profiles are available when creating a pool.
 Please see the `btrfs wiki <https://btrfs.wiki.kernel.org/index.php/Main_Page>`_
 for up to date information on all btrfs matters.
 
+For a BTRFS features stability status overview, including redundancy profiles,
+vist the  `btrfs wiki status page <https://btrfs.wiki.kernel.org/index.php/Status>`_.
+
 Compression Options
 ^^^^^^^^^^^^^^^^^^^
 
@@ -99,7 +102,7 @@ These are optional and meant for more advanced users to provide BTRFS specific
 mount options. Since a Pool is a filesystem, it is mounted with default options
 which can be altered by providing one or more of the following. You can find
 out more about each option from the `btrfs wiki mount options section
-<https://btrfs.wiki.kernel.org/index.php/Mount_options>`_.
+<https://btrfs.wiki.kernel.org/index.php/Manpage/btrfs(5)#MOUNT_OPTIONS>`_.
 
 * **alloc_start**
 * **autodefrag**
@@ -225,3 +228,4 @@ wiki balance section
 
 To start a balance, go to the Pool's detail page and click on the **Start a new
 balance** button in the **Balances** tab.
+


### PR DESCRIPTION
added link to BTRFS Feature status page
Updated bad mount options link to new mount options page

closes #176  
closes #155 

Good sphinx build and ops check

C:\Users\Del\Documents\GitHub\rockstor-doc>make html
Running Sphinx v1.8.4
loading pickled environment... done
building [mo]: targets for 0 po files that are out of date
building [html]: targets for 1 source files that are out of date
updating environment: [] 0 added, 1 changed, 0 removed
reading sources... [100%] pools-btrfs
looking for now-outdated files... none found
pickling environment... done
checking consistency... done
preparing documents... done
writing output... [100%] pools-btrfs
generating indices... genindex
writing additional pages... search
copying images... [100%] images/delete_pool.png
copying static files... WARNING: html_static_path entry 'C:\\Users\\Del\\Docume
ts\\GitHub\\rockstor-doc\\_static' does not exist
done
copying extra files... done
dumping search index in English (code: en) ... done
dumping object inventory... done
build succeeded, 1 warning.
The HTML pages are in _build\html.
Build finished. The HTML pages are in _build/html.