### PR TITLE
remove google analytics. Fixes #204

### DIFF
--- a/themes/rockstor/layout.html
+++ b/themes/rockstor/layout.html
@@ -9,19 +9,6 @@
 <script src="http://use.edgefonts.net/source-sans-pro.js"></script>
 <script src="{{ pathto('_static/' + 'js/libs/bootstrap.js', 1) }}"></script>
 <link rel="shortcut icon" href="{{ pathto('_static/' + 'img/ico/favicon.ico', 1) }}" type="image/x-icon" />
-
-
-    <script>
-     (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-      (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-      m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-      })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-
-      ga('create', 'UA-46730615-1', 'rockstor.com');
-      ga('send', 'pageview');
-    </script>
-
-
 {%- endblock %}
 
 {%- block doctype -%}


### PR DESCRIPTION
In keeping with more modern preferences and to improve docs responsiveness we can remove our script entry for Google Analytics.

Tested using 64bit Sphinx v1.6.5
No errors indicated.

Fixes #204 

No user visible changes in this pull request.