### PR TITLE
remove warning on first make html. Fixes #209

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -133,7 +133,7 @@ html_logo = 'rockstorlogo-font2.png'
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = ['_static']
+html_static_path = []
 
 # Add any extra paths that contain custom files (such as robots.txt or
 # .htaccess) here, relative to this directory. These files are copied


### PR DESCRIPTION
By removing the now redundant '_static' entry in the html_static_path option in conf.py we allow for automated Sphinx builds to fail on any warnings. And as we currently have no other warnings this would help to ensure that we catch any future warning prior to publishing.

Fixes #209 

Testing,
A fresh 'make html' build via Python3 Sphinx v1.6.5 would always generate the '... _static' does not exist warning. Post merge of this pr resolves this issue which will enable our use of strict_warnings within our buildbot build system.