### PR TITLE
remove embedded youtube videos. Fixes #222

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -31,7 +31,6 @@ import os
 extensions = [
     'sphinx.ext.todo',
     'sphinxcontrib.fulltoc',
-    'sphinxcontrib.youtube',
 ]
 
 # Add any paths that contain templates here, relative to this directory.

--- a/contribute.rst
+++ b/contribute.rst
@@ -88,8 +88,9 @@ Go to `rockstor-core repo <https://github.com/rockstor/rockstor-core>`_ and
 click on the "Fork" button. This will fork the repository into your profile
 which serves as your private git remote called origin. The next few git steps are
 demonstrated on a Linux terminal. They work the same on a Mac too. Your IDE may
-have ways to completely avoid the terminal, but using the terminal makes you
-`look cool <https://www.youtube.com/watch?v=51lGCTgqE_w>`_.
+have ways to completely avoid the terminal, but using the terminal makes you look cool:
+
+See YouTube `Trinity in the UNIX shell..... <https://www.youtube.com/watch?v=51lGCTgqE_w>`_.
 
 Your development machine can be a Linux system or a Mac. In my case, it's a
 Lenovo laptop running Ubuntu. There are other contributors using Mac, so this
@@ -171,13 +172,14 @@ Build VM
 
 You need a Virtual Machine (VM) to build and test your changes. An easy
 solution is to create a Rockstor VM using either Oracle's `VirtualBox
-<https://www.virtualbox.org/>`_ or if you are using a Linux desktop then
-`Virtual Machine Manager <https://virt-manager.org>`_ is also an option. You
-can find a `VirtualBox Rockstor install demo
-<https://www.youtube.com/watch?v=00k_RwwC5Ms>`_ on our `YouTube channel
-<https://www.youtube.com/channel/UCOr8Q4DA7gYDpeSv09BVCRQ>`_ and a
-:ref:`kvmsetup` in our documentation. It need not be a VM, but using a physical
-machine just for this purpose could be an overkill.
+<https://www.virtualbox.org/>`_:
+
+See YouTube `Rockstor 3 0 installation demo <https://www.youtube.com/watch?v=00k_RwwC5Ms>`_.
+
+or if you are using a Linux desktop then `Virtual Machine Manager (VMM) <https://virt-manager.org>`_ is a more native option.
+VMM is used in our :ref:`kvmsetup` howto.
+It need not be a VM, but using a physical machine just for this purpose could be overkill.
+
 
 Note that when you first create the build VM, Rockstor rpm package will already
 be installed. The package files are located in /opt/rockstor. Further more, the

--- a/contribute_documentation.rst
+++ b/contribute_documentation.rst
@@ -106,36 +106,26 @@ follow the appropriate installation guide for Sphinx.
 
 Installing Sphinx
 ^^^^^^^^^^^^^^^^^
-In order to properly develop and submit contributions you'll need to install Sphinx, plus two sphinx extensions
+In order to properly develop and submit contributions you'll need to install Sphinx, plus one Sphinx extensions
+
+`Sphinx official documentation <http://www.sphinx-doc.org/en/master/#>`_ gives guidelines for installating Sphinx on various platforms.
+Details of how to install Sphinx is covered in their  `Installing Spinx <http://www.sphinx-doc.org/en/master/usage/installation.html>`_ documentation.
+
+Once you have Sphinx installed you'll need 1 more Sphinx extensions before you're fully ready.
+The sphinxcontrib-fulltoc package, generates the sidebar table of contents.
 
 `sphinxcontrib-fulltoc <https://pypi.org/project/sphinxcontrib-fulltoc/>`_ generates detailed sidebar table of contents.
-
-`sphinxcontrib.youtube <https://pypi.org/project/sphinxcontrib.youtube/>`_ used if you create a video to demonstrate Rockstor functionality 
-
-`Sphinx official documentation <http://www.sphinx-doc.org/en/master/#>`_ gives guidelines for installating Sphinx on various platforms. Details of how to install Sphinx is covered in their  `Installing Spinx <http://www.sphinx-doc.org/en/master/usage/installation.html>`_ documentation.
-
-Once you have Sphinx installed you'll need 2 more Sphinx extensions before you're fully ready.  The 
-sphinxcontrib-youtube package, allows you to embed videos into your documentation pages to explain 
-Rockstor features or functionality.  The sphinxcontrib-fulltoc package, generates the sidebar table of contents.
 
 While you may not use the functionality of these extensions in your page, when you execute a *make html*
 to check your work, you'll need these packages for the make to complete successfully.  
 If you are generating videos, and prefer uploading your videos to the Rockstor Youtube channel,
 please, send an email to support@rockstor.com
 
-As of this writing, there is a minor problem with the sphinxcontrib.youtube extension for Python 3, below you'll find the
-commands to install sphinxcontrib.youtube, and sphinxcontrib-fulltoc broken out in Python 2, and Python 3 sections.  The 
-Python 3 sphinxcontrib.youtube pulls a fixed version from github.
-
 For a **Python 2** installation, use these commands. ::
-
-	[you@your_laptop /path/to/rockstor-doc]# sudo pip install sphinxcontrib.youtube
 
 	[you@your_laptop /path/to/rockstor-doc]# sudo pip install --user sphinxcontrib-fulltoc
 	
-For a **Python 3** installation, use these commands.  ::
-
-	[you@your_laptop /path/to/rockstor-doc]# sudo pip3 install --user git+https://github.com/shomah4a/sphinxcontrib.youtube.git@404e8f17c2505333a0781a62800c5a8a08ba3c52
+For a **Python 3** installation, favoured, use these commands.  ::
 
 	[you@your_laptop /path/to/rockstor-doc]# sudo pip3 install --user sphinxcontrib-fulltoc
 	

--- a/install.rst
+++ b/install.rst
@@ -13,14 +13,14 @@ that we have a :ref:`pre_install`.
 Quick evaluation using a virtual environment
 --------------------------------------------
 
-Rockstor can also be evaluated quickly using a virtual machine.
+Rockstor can also be evaluated quickly using a virtual machine, see our  :ref:`kvmsetup`.
 
-See our YouTube `VirtualBox Rockstor install demo
-<https://www.youtube.com/watch?v=00k_RwwC5Ms>`_ or our :ref:`kvmsetup`
+See YouTube `VirtualBox Rockstor install demo <https://www.youtube.com/watch?v=00k_RwwC5Ms>`_.
 
 Before proceeding with a serious installation that may require hardware
-procurement, you can evaluate Rockstor on Amazon AWS. See our YouTube video on `Rockstor on ec2
-<https://www.youtube.com/watch?v=ys_8FLVov2U>`_.
+procurement, you can evaluate Rockstor on Amazon AWS.
+
+See YouTube `Rockstor on ec2 <https://www.youtube.com/watch?v=ys_8FLVov2U>`_.
 
 Hardware recommendations
 -------------------------
@@ -80,7 +80,9 @@ Rockstor is under continuous development and we push tested updates in small bat
 
 Rockstor updates can be installed in two ways :
 
-1. Install updates from the Web-UI : On the Rockstor Web-UI, on the top-right side of the navigation bar, you will see an upward facing arrow. If you click on that arrow, and if there is an update available, you will see *Software Update* highlighted, with details on the screen. This `video <https://www.youtube.com/watch?v=srn6vgQNkbc>`_ also illustrates the process of update from Web-UI.
+1. Install updates from the Web-UI : On the Rockstor Web-UI, on the top-right side of the navigation bar, you will see an upward facing arrow. If you click on that arrow, and if there is an update available, you will see *Software Update* highlighted, with details on the screen.
+
+See YouTube `How to keep Rockstor upto date <https://www.youtube.com/watch?v=srn6vgQNkbc>`_.
 
 .. image:: images/install-update.png
    :scale: 60%

--- a/mdraid-mirror/boot_drive_howto.rst
+++ b/mdraid-mirror/boot_drive_howto.rst
@@ -45,10 +45,11 @@ In this howto we will use `Linux Raid
 drive mirror. This can be done as part of Rockstor's installation but requires
 many more additional steps from a default, non mdraid, install. If you
 have never installed Rockstor before, we recommend you read our
-:ref:`quickstartguide` guide and watch `this install video
-<https://www.youtube.com/watch?v=yEL8xMhMctw>`_ before proceeding with this
-howto as the default kickstarter based install method is recommended for most
-users.
+:ref:`quickstartguide`, also:
+
+See YouTube `How to install Rockstor 3.8-7 <https://www.youtube.com/watch?v=yEL8xMhMctw>`_
+
+before proceeding with this howto as the default kickstarter based install method is recommended for most users.
 
 .. _mdraidos_requirements:
 

--- a/nfs_ops.rst
+++ b/nfs_ops.rst
@@ -29,9 +29,9 @@ Add NFS export
 ^^^^^^^^^^^^^^
 
 A single NFS export represents a unique combination of clients to which a set
-of shares are made accessible via chosen options. Go to the *NFS* view under the *Storage* tab of the Web-UI and click on **Add NFS Export** button to add a new NFS export as shown in the video below.
+of shares are made accessible via chosen options. Go to the *NFS* view under the *Storage* tab of the Web-UI and click on **Add NFS Export** button to add a new NFS export.
 
-.. youtube:: https://www.youtube.com/watch?v=4xRsIIbXYXI
+See YouTube `Create NFS export of a share <https://www.youtube.com/watch?v=4xRsIIbXYXI>`_.
 
 Various fields of the form are explained as follows.
 
@@ -46,14 +46,9 @@ Edit NFS export
 ^^^^^^^^^^^^^^^
 
 An NFS export can be edited to add or remove a Share or allow different set of
-clients to be able to access it. In the displayed table of NFS exports under the *NFS* view of the Web-UI, click on the **edit** icon of the corresponding export to edit as shown in the video below.
+clients to be able to access it. In the displayed table of NFS exports under the *NFS* view of the Web-UI, click on the **edit** icon of the corresponding export to edit.
 
-.. youtube:: https://www.youtube.com/watch?v=OSs6BteniX0
-
-Advanced Edit
-^^^^^^^^^^^^^
-
-
+See YouTube `Edit NFS export of a share <https://www.youtube.com/watch?v=OSs6BteniX0>`_.
 
 Delete NFS export
 ^^^^^^^^^^^^^^^^^

--- a/pools-btrfs.rst
+++ b/pools-btrfs.rst
@@ -25,9 +25,9 @@ imported. For more information, see :ref:`reinstall_import_data`.
 
 Click on **Create Pool** button and submit the create pool form to create a
 pool. There is a tooltip for each input field to help you choose appropriate
-parameters. Here's a video showing this operation.
+parameters.
 
-.. youtube:: https://www.youtube.com/watch?v=T5sg8xSoH1E
+See YouTube `Creating a Pool <https://www.youtube.com/watch?v=T5sg8xSoH1E>`_.
 
 
 .. _redundancyprofiles:
@@ -152,20 +152,18 @@ to finish.
 Redundancy profile changes
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-You can change :ref:`redundancyprofiles` online with very few
-restrictions. This video shows how to change a Pool from RAID1 to RAID10.
+You can change :ref:`redundancyprofiles` online with very few restrictions.
 
-.. youtube:: https://www.youtube.com/watch?v=DouOx8gX5yE
+See YouTube `Change Pool's RAID profile <https://www.youtube.com/watch?v=DouOx8gX5yE>`_.
 
 .. _pooladddisks:
 
 Adding Disks
 ^^^^^^^^^^^^
 
-Disks can be added to a Pool online and expand capacity.  This video shows how
-to expand a RAID1 Pool by adding three disks.
+Disks can be added to a Pool online and expand capacity.
 
-.. youtube:: https://www.youtube.com/watch?v=E37rzWcwGu0
+See YouTube `Adding disks to a Pool <https://www.youtube.com/watch?v=E37rzWcwGu0>`_.
 
 .. _poolremovedisks:
 
@@ -174,10 +172,9 @@ Removing Disks
 
 Disks can be removed from a Pool online similar to adding Disks. However, since
 it results in reduced capacity, this operation can succeed only if the
-resulting capacity after removal is greater than the current usage. This video
-shows how to remove two disks from a RAID1 Pool made up of four disks.
+resulting capacity after removal is greater than the current usage.
 
-.. youtube:: https://www.youtube.com/watch?v=535pxsF16Pk
+See YouTube `Removing disks from a Pool <https://www.youtube.com/watch?v=535pxsF16Pk>`_.
 
 
 Pool deletion

--- a/quickstart.rst
+++ b/quickstart.rst
@@ -136,8 +136,11 @@ untested, please see our :ref:`makeusbinstalldiskgui`.
 Installation
 ------------
 
-Installing Rockstor is quick and straight forward as shown in `this install
-video <https://www.youtube.com/watch?v=yEL8xMhMctw>`_. Since Rockstor is based
+Installing Rockstor is quick and straight forward.
+
+See YouTube `How to install Rockstor 3.8-7 <https://www.youtube.com/watch?v=yEL8xMhMctw>`_.
+
+Since Rockstor is based
 on CentOS and uses the same anaconda installer the installation looks similar
 to that of CentOS or Fedora. You can also read
 :ref:`vmmrockstorinstall` section of our :ref:`kvmsetup` for more information

--- a/samba_ops.rst
+++ b/samba_ops.rst
@@ -31,8 +31,7 @@ Set *Guest OK* to *yes* if you want to permit guest access.
 
 Set *Read only* to *yes* if the share should not be writable by clients.
 
-
-.. youtube:: https://www.youtube.com/watch?v=hZ7FQWuF6TI
+See YouTube `Create a Samba SMB export of a share <https://www.youtube.com/watch?v=hZ7FQWuF6TI>`_.
 
 View Samba Export
 ^^^^^^^^^^^^^^^^^

--- a/shares-btrfs-subvolumes.rst
+++ b/shares-btrfs-subvolumes.rst
@@ -22,24 +22,22 @@ Creating a share
 Since Shares are BTRFS subvolumes, they can be created and resized instantly to
 grow and shrink capacity at a later time. Click on **Create Share** button and
 submit the Share creation form to create one. There is a tooltip for each input
-field to help you choose appropriate parameters. Here's a video showing this
-operation.
+field to help you choose appropriate parameters.
 
-.. youtube:: https://www.youtube.com/watch?v=k537gsx8ifQ
-
+See YouTube `Create a Rockstor Share <https://www.youtube.com/watch?v=k537gsx8ifQ>`_.
 
 Resizing a share
 ----------------
 
 A share can be resized by increasing or decreasing it's provisioned
-capacity. To resize a Share, Click the **Resize** button in it's detail screen
-as shown in this video
+capacity. To resize a Share, Click the **Resize** button in it's detail screen.
 
-.. youtube:: https://www.youtube.com/watch?v=vMCNZFDwKLQ
+See YouTube `Resize a Rockstor Share <https://www.youtube.com/watch?v=vMCNZFDwKLQ>`_.
 
 Note that a share cannot be decreased to a capacity lower than it's current
 usage. Internally, Share capacity enforcement is done via BTRFS qgroup feature
-set. To find out more, go `here <https://btrfs.wiki.kernel.org/index.php/Quota_support>`_.
+set. To find out more see the btrfs wiki entry
+`Quota_support <https://btrfs.wiki.kernel.org/index.php/Quota_support>`_.
 
 .. _sizedisabled:
 
@@ -83,9 +81,8 @@ created from, at the time that it was created.
 
 In Rockstor, both Shares and Snapshots can be cloned to create new Shares.
 
-To clone a Share, got to it's detail screen and click on the **Clone** button
-as shown in this video.
+To clone a Share, got to it's detail screen and click on the **Clone** button.
 
-.. youtube:: https://www.youtube.com/watch?v=DhXUyDoBVMY
+See YouTube `Clone a Share <https://www.youtube.com/watch?v=DhXUyDoBVMY>`_.
 
 To clone a Snapshot, see :ref:`clonesnapshot`.

--- a/snapshots-btrfs-snapshots.rst
+++ b/snapshots-btrfs-snapshots.rst
@@ -38,18 +38,18 @@ Creating a Snapshot
 
 To create a Snapshot, use the **Create Snapshot** button and submit the form
 with your chosen input values. There is a tooltip for each input field with
-more help. Here's a sample video showing this operation.
+more help.
 
-.. youtube:: https://www.youtube.com/watch?v=QTQePwrYMS0
+See YouTube `Create a Snapshot <https://www.youtube.com/watch?v=QTQePwrYMS0>`_.
 
 Scheduling Snapshots
 --------------------
 
 Using Rockstor's :ref:`tasks` system it is also possible to schedule Snapshot
 creation automatically at a predefined time and frequency similar to cronjobs
-in Linux. To find out more, see :ref:`snapshottask` or see this video.
+in Linux. To find out more, see :ref:`snapshottask`.
 
-.. youtube:: https://www.youtube.com/watch?v=PA0hneCq-AE
+See YouTube `Schedule a Snapshot <https://www.youtube.com/watch?v=PA0hneCq-AE>`_.
 
 You can also schedule Snapshots such that the frequency decreases over
 time. For example, you can schedule 12 hourly Snapshots during the day, 4
@@ -78,9 +78,9 @@ A Snapshot can be cloned to create a brand new Share. This is useful if you
 wish to create a new Share that is an exact copy of the Snapshot.
 
 To clone a Snapshot, click on the clone icon in the **Actions** column of the
-Snapshot table as shown in this video.
+Snapshot table.
 
-.. youtube:: https://www.youtube.com/watch?v=aySlQCx65GM
+See YouTube `Clone a Snapshot <https://www.youtube.com/watch?v=aySlQCx65GM>`_.
 
 To clone a Share, see :ref:`cloneshare`.
 
@@ -90,9 +90,9 @@ Rolling back a Share
 A Share can be rolled back to any of its snapshots. This is useful if you wish
 to restore a Share to it's previous state represented by its snapshots
 
-Click on the **Rollback** button in the Share's detail screen as shown in this video.
+Click on the **Rollback** button in the Share's detail screen.
 
-.. youtube:: https://www.youtube.com/watch?v=r0SbCZ_kEBg
+See YouTube `Rollback a Share to a specific Snapshot <https://www.youtube.com/watch?v=r0SbCZ_kEBg>`_.
 
 *Note:* Shares that are exported through NFS or Samba cannot be rolled back. The
 NFS or Samba shares should be deleted before the share can be rolled back.

--- a/themes/rockstor/layout.html
+++ b/themes/rockstor/layout.html
@@ -8,6 +8,10 @@
 <title>Rockstor | Linux and BTRFS powered Opensource NAS solution</title>
 <script src="http://use.edgefonts.net/source-sans-pro.js"></script>
 <script src="{{ pathto('_static/' + 'js/libs/bootstrap.js', 1) }}"></script>
+<script type="text/javascript">
+    <!-- Adds target=_blank to external links -->
+    $(document).ready(function () {$('a[href^="http://"], a[href^="https://"]').not('a[class*=internal]').attr('target', '_blank');});
+</script>
 <link rel="shortcut icon" href="{{ pathto('_static/' + 'img/ico/favicon.ico', 1) }}" type="image/x-icon" />
 {%- endblock %}
 
@@ -50,7 +54,6 @@
                         <li><a href="https://github.com/rockstor/rockstor-core/issues" target="_blank">Issue Tracker</a></li>
                     </ul>
                 </li>
-                <li><a href="/blog">Blog</a></li>
                 <li>&nbsp;</li>
                 <li>&nbsp;</li>
 

--- a/uis.rst
+++ b/uis.rst
@@ -30,9 +30,9 @@ https://<appliance_ip> in your browser.
 The setup process consists of two screens. In the first screen, an admin user
 must be created by entering desired credentials. In the second screen, all
 disks detected in the system are displayed. Click next to finish the setup
-process as shown below.
+process.
 
-.. youtube:: https://www.youtube.com/watch?v=MvdkoPeTLm8
-   
+See YouTube `Rockstor Web UI <https://www.youtube.com/watch?v=MvdkoPeTLm8>`_.
+
 Once the setup process is complete, the newly created admin user is logged in
 and the Rockstor dashboard is displayed.

--- a/windows-shadow-copy.rst
+++ b/windows-shadow-copy.rst
@@ -29,10 +29,7 @@ should choose the *Snapshot prefix* field to be unique enough that it will not
 clash with directory or filenames. Eg: SNAPSHOT. The rest of the input in the
 form is same as it would be for any other Samba export.
 
-Here's an example video demonstration.
-
-.. youtube:: https://www.youtube.com/watch?v=XAe8OlO3O38
-
+See YouTube `Rockstor shadow copy support part 1 of 3 <https://www.youtube.com/watch?v=XAe8OlO3O38>`_.
 
 Step 2: Schedule Snapshots
 --------------------------
@@ -43,9 +40,7 @@ clicking the *Schedule a Task* button. The important input parameter here is
 the *Snapshot prefix*. It must be the same string from the previous step. Eg:
 SNAPSHOT. Choose rest of the input according to your needs.
 
-Here's an example video demonstration.
-
-.. youtube:: https://www.youtube.com/watch?v=kh4O11x5vy8
+See YouTube `Rockstor shadow copy support part 2 of 3 <https://www.youtube.com/watch?v=kh4O11x5vy8>`_.
 
 
 Step 3: Access Snapshots from Windows
@@ -60,6 +55,6 @@ As the time goes by, files are added, edited and deleted from the
 Share by the client. Meanwhile, Snapshots are taken on Rockstor periodically and result in
 *Previous versions* or *Shadow copies* for files. To access previous versions
 of a file from Windows, go to it's *Properties* window and
-click on *Previous Versions* tab as shown in this video.
+click on *Previous Versions* tab.
 
-.. youtube:: https://www.youtube.com/watch?v=_YxIEc0OD-M
+See YouTube `Rockstor shadow copy support part 3 of 3 <https://www.youtube.com/watch?v=_YxIEc0OD-M>`_.


### PR DESCRIPTION
See related issue text for context:

Fixes #222

Includes:
- Change all embedded YouTube instances to regular YouTube links
- Remove sphinxcontrib.youtube from required Sphinx extensions
- Removing Sphinx YouTube plugin related instructions.
- Add js script to layout so external links are opened in new tab. This
adds target="_blank" to all http|https links that are not internal.

and additionally via:
- remove defunct "Blog" entry.

Fixes #219