### PR TITLE
Update config backup and restore to document new rock-ons support

### DIFF
--- a/config_backup/config_backup.rst
+++ b/config_backup/config_backup.rst
@@ -14,14 +14,26 @@ extensive configuration changes as it provides the possibility to revert to a
 known good configuration. Once a configuration backup has been generated and
 downloaded it can also be used in system migration scenarios.
 
+.. raw:: html
+
+   <div class="alert alert-warning">
+   Upon restore, the configuration of most features included in the backup
+   will be restored regardless of their current state. As a result, their current
+   configuration will be overwritten (to the exception of <em>Users</em> and
+   <em>Groups</em>, see <a href="#special-notes-on-configuration-restore">below</a>).
+   </div>
+
 The following state information is saved as part of a backup
 
 * Users and Groups
-* Samba configuration
-* NFS configuration
-* AFP configuration
+* Samba configuration and exports
+* NFS configuration and exports
+* AFP configuration and exports
+* Schedule task configuration
 * Service configurations (ntp, smartd etc..)
+* Service status (on / off)
 * Scheduled task configuration
+* Rock-on configuration
 
 Since Rockstor can dynamically detect  :ref:`Pool <pools>`,  :ref:`Share <shares>`, and :ref:`Snapshot <snapshots>` information
 after an external change like a :ref:`reinstallation <reinstall>`, there is no need to save this
@@ -33,7 +45,6 @@ plans to add these states to the list of saved states in the future.
 * Appliance configurations
 * Dashboard customizations
 * Network interface settings
-* Rock-on configuration
 
 This feature is found in the **Config Backups** section on the **System** page.
 
@@ -99,3 +110,23 @@ previously and is now ready to be applied using the **Play** icon as usual.
 **All configuration backups are stored in zipped json format in the
 /opt/rockstor/static/config-backups directory**
 
+..  _config_notes:
+
+Special Notes on Configuration Restore
+--------------------------------------
+
+As mentioned above, restoring a configuration backup will reset your system
+configuration but a few points should be mentioned:
+
+* **Preparation**: a lot of configuration settings such as NFS/Samba exports,
+  services configuration, or rock-ons, depend on the presence of specific shares
+  on the system. In a Rockstor reinstallation scenario, it is thus recommended to
+  first :ref:`import pools and shares <reinstall_import_data>` from the disk before
+  restore a configuration backup.
+* **Time**: upon restore, all settings may take some time to propagate, depending
+  on the size of the backup. If a particular setting doesn't seem to be restored
+  immediately, try refreshing the page after a few minutes. Rock-ons, for instance,
+  can take several seconds to minutes to be re-installed if necessary.
+* **Users and Groups**: only those present in the backup but not in the current
+  system will be restored. This means that users and groups  created after the backup
+  will not be deleted upon config backup restore.


### PR DESCRIPTION
Fixes #227 

### This pull request's proposal
Following the recent support for rock-ons in the Config Backup & Restore feature, this pull request proposes to first update the documentation to reflect that new support, but also further develop notes to the users, and specifies a few implied (but missing) points.

#### Details
1. _Rock-ons_ are moved from the list of planned features to the list of supported features.
2. We now specify that _exports_ are included with regards to AFP/NFS/Samba configuration.
3. Add warning block clearly specifying that the current system settings will be partially overwritten by a restore.
4. Add a _special notes_ section with further details on the expected behavior.

#### Sphinx build
```
>make html
Running Sphinx v2.3.1
making output directory... done
building [mo]: targets for 0 po files that are out of date
building [html]: targets for 61 source files that are out of date
updating environment: [new config] 61 added, 0 changed, 0 removed
reading sources... [100%] windows-shadow-copy
looking for now-outdated files... none found
pickling environment... done
checking consistency... done
preparing documents... done
writing output... [100%] windows-shadow-copy
generating indices...  genindexdone
writing additional pages...  searchdone
copying images... [100%] change-password.gif     
copying static files... ... done
copying extra files... done
dumping search index in English (code: en)... done
dumping object inventory... done
build succeeded.

The HTML pages are in _build\html.

Build finished. The HTML pages are in _build/html.
```

### Checklist
- [x] With the proposed changes no Sphinx errors or warnings are generated.
- [x] I have added my name to the AUTHORS file, if required (descending alphabetical order).