### PR TITLE
Correct minor typo in config_backup.rst

### DIFF
--- a/config_backup/config_backup.rst
+++ b/config_backup/config_backup.rst
@@ -122,7 +122,7 @@ configuration but a few points should be mentioned:
   services configuration, or rock-ons, depend on the presence of specific shares
   on the system. In a Rockstor reinstallation scenario, it is thus recommended to
   first :ref:`import pools and shares <reinstall_import_data>` from the disk before
-  restore a configuration backup.
+  restoring a configuration backup.
 * **Time**: upon restore, all settings may take some time to propagate, depending
   on the size of the backup. If a particular setting doesn't seem to be restored
   immediately, try refreshing the page after a few minutes. Rock-ons, for instance,


### PR DESCRIPTION
### This pull request's proposal
During his review of #228 , a minor typo was identified by @phillxnet. This PR simply proposes to correct that typo from "restore a" to "restoring a" in the _Special notes_ section at the end of config_backup.rst.


### Checklist
- [x] With the proposed changes no Sphinx errors or warnings are generated.
- [x] I have added my name to the AUTHORS file, if required (descending alphabetical order).