### PR TITLE
Replaced 'e-mail' with 'email'

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -11,6 +11,7 @@ Nathan Friedly
 Mirko Arena
 Mazo
 lifton
+Jon Wilson
 HBDK
 Gompa
 FroggyFlox

--- a/docker-based-rock-ons/discourse.rst
+++ b/docker-based-rock-ons/discourse.rst
@@ -91,7 +91,7 @@ Discourse Mail Credentials
 
 Discourse now requires the following email details / credentials:-
 
-* **Admin e-mail** - email of the forum admin eg suman@rockstor.com
+* **Admin email** - email of the forum admin eg suman@rockstor.com
 * **Forum web address** - FQDN eg forum.rockstor.com
 * **SMTP server** - eg smtp.gmail.com
 * **SMTP port** - eg 587

--- a/email_setup.rst
+++ b/email_setup.rst
@@ -3,11 +3,11 @@
 Email Notifications
 ===================
 
-Rockstor integrates an easy to use e-mail/postfix configuration section that
-enables e-mail notifications.  By default all local root (system) e-mail will
-be forwarded to a specified e-mail address.  This is accomplished by using a
-dedicated (configurable) e-mail account that Rockstor can login too and send
-e-mail from.
+Rockstor integrates an easy to use email/postfix configuration section that
+enables email notifications.  By default all local root (system) email will
+be forwarded to a specified email address.  This is accomplished by using a
+dedicated (configurable) email account that Rockstor can login too and send
+email from.
 
 .. _email_setup:
 
@@ -20,7 +20,7 @@ Navigate to the **Email Alerts** section of the **System** page:-
     :scale: 80%
     :align: center
 
-Press the **Add an E-Mail account** button to begin.
+Press the **Add an Email account** button to begin.
 
 Complete the following required fields
 

--- a/faq.rst
+++ b/faq.rst
@@ -249,7 +249,7 @@ How can I contribute to Rockstor?
 
 Thanks for asking and welcome to the Rockstor community. Depending on your
 needs and interests, there are a few ways to participate. See
-:ref:`contributetorockstor` for more details. Don't feel shy and e-mail any of
+:ref:`contributetorockstor` for more details. Don't feel shy and email any of
 the developers if you like to discuss more before jumping in!
 
 

--- a/quickstart.rst
+++ b/quickstart.rst
@@ -155,7 +155,7 @@ about installation.
 
    <div class="alert alert-info">
    If you need further assistance during or post install, you
-   can post a topic on our <a href="http://forum.rockstor.com">Forum</a> or send an e-mail to support@rockstor.com
+   can post a topic on our <a href="http://forum.rockstor.com">Forum</a> or send an email to support@rockstor.com
    </div>
 
 1. Boot your machine with the Rockstor CD or USB and the splash screen will


### PR DESCRIPTION
Fixes #230 

### This pull request's proposal

Replaced references to 'e-mail' with 'email'

### Checklist
- [x] With the proposed changes no Sphinx errors or warnings are generated.
- [x] I have added my name to the AUTHORS file, if required (descending alphabetical order).