### PR TITLE
minor clarifications to contributing rock-ons doc section. Fixes #238

### DIFF
--- a/contribute_rockons.rst
+++ b/contribute_rockons.rst
@@ -59,7 +59,7 @@ Deleting a Rock-on
 ==================
 
 The Rock-ons repository is predominantly community maintained/led.
-As such we depend on community involvement to maintain it's health.
+As such we depend on community involvement to maintain its health.
 On occasions a Rock-on will fall into dis-repair.
 If you find such a Rock-on, ie broken or build on an abandoned/deprecated docker image,
 then please report this on our `friendly forum <https://forum.rockstor.com/>`_.

--- a/contribute_rockons.rst
+++ b/contribute_rockons.rst
@@ -20,7 +20,7 @@ A GitHub account is required.
 
 1. Create a *New issue* (button) in the **rockon-registry** `issues section <https://github.com/rockstor/rockon-registry/issues>`_ and explain what you are proposing.
 2. Creating your own *Fork* (button) of the `rockon-registry <https://github.com/rockstor/rockon-registry>`_ (GitHub login required).
-3. Write and test your Rock-on definition file following the `README.md <https://github.com/rockstor/rockon-registry/blob/master/README.md>`_.
+3. Write and test your Rock-on JSON definition file following the `README.md <https://github.com/rockstor/rockon-registry/blob/master/README.md>`_.
 4. In your forked copy on GitHub select **create new file** (button) and paste your JSON file and name it (no spaces).
 5. Before **Commit new file** (button) ensure  **"Create a new branch for this commit and start a pull request..."** is selected.
 6. After the selection in 5. change the suggested branch name to e.g. **"#1234 Add project Y as Rock-on"** where the number is that of your issue.

--- a/contribute_rockons.rst
+++ b/contribute_rockons.rst
@@ -64,7 +64,7 @@ On occasions a Rock-on will fall into disrepair.
 If you find such a Rock-on, ie broken or build on an abandoned/deprecated docker image,
 then please report this on our `friendly forum <https://forum.rockstor.com/>`_.
 If there is then no community will/effort to maintain/repair that rock-on, then we will happily accept a pull request to delete it.
-Such a pull request would include the removal/deletion of the associated JSON definition file and it's associated entry within the root.json file.
+Such a pull request would include the removal/deletion of the associated JSON definition file and its associated entry within the root.json file.
 Please reference the relevant forum discussion upon submitting such a pull request and limit each such Rock-on delete request to a single Rock-on.
 Such 'weeding' is definitely encouraged and contributes to the overall health of this repository and the project as a whole.
 It's always frustrating to find something broken and if the community will is not there to repair it then it's best removed.

--- a/contribute_rockons.rst
+++ b/contribute_rockons.rst
@@ -63,7 +63,7 @@ As such we depend on community involvement to maintain its health.
 On occasions a Rock-on will fall into disrepair.
 If you find such a Rock-on, ie broken or build on an abandoned/deprecated docker image,
 then please report this on our `friendly forum <https://forum.rockstor.com/>`_.
-If there is then no community will/effort to maintain/repair that rock-on then we will happily accept a pull request to delete it.
+If there is then no community will/effort to maintain/repair that rock-on, then we will happily accept a pull request to delete it.
 Such a pull request would include the removal/deletion of the associated JSON definition file and it's associated entry within the root.json file.
 Please reference the relevant forum discussion upon submitting such a pull request and limit each such Rock-on delete request to a single Rock-on.
 Such 'weeding' is definitely encouraged and contributes to the overall health of this repository and the project as a whole.

--- a/contribute_rockons.rst
+++ b/contribute_rockons.rst
@@ -60,7 +60,7 @@ Deleting a Rock-on
 
 The Rock-ons repository is predominantly community maintained/led.
 As such we depend on community involvement to maintain its health.
-On occasions a Rock-on will fall into dis-repair.
+On occasions a Rock-on will fall into disrepair.
 If you find such a Rock-on, ie broken or build on an abandoned/deprecated docker image,
 then please report this on our `friendly forum <https://forum.rockstor.com/>`_.
 If there is then no community will/effort to maintain/repair that rock-on then we will happily accept a pull request to delete it.

--- a/contribute_rockons.rst
+++ b/contribute_rockons.rst
@@ -1,29 +1,31 @@
 .. _contributerockons:
 
-Contributing to Rockstor Rock-ons
-======================================
+Contributing a Rock-on
+======================
 
 Rock-ons are Docker plugins (see :ref:`rockons_intro` for more information) 
 defined by a JSON file stored in the **rockon-registry** repository on 
-`github.com <https://github.com/rockstor/rockon-registry>`_. As detailed
-in the :ref:`adding_rockons` section, please refer to rockon-registry `README.md <https://github.com/rockstor/rockon-registry/blob/master/README.md>`_ 
+`github.com <https://github.com/rockstor/rockon-registry>`_.
+As detailed in the :ref:`adding_rockons` section,
+please refer to the rockon-registry `README.md <https://github.com/rockstor/rockon-registry/blob/master/README.md>`_
 for full instructions and examples on how to write your own Rock-on definition file.
 
-If you are interested in donating a Rock-on for your favorite project, please 
-consider contributing to the `rockon-registry <https://github.com/rockstor/rockon-registry>`_ 
-by submitting a pull-request. Steps for doing so are similar to those required 
-for :ref:`contributetorockstor` or :ref:`contributedocs`. Briefly, these would 
-consist in: 
+If you are interested in contributing a Rock-on to enable your chosen project on Rockstor,
+please submit a pull-request to the `rockon-registry <https://github.com/rockstor/rockon-registry>`_.
+Steps for doing so are similar to those required for :ref:`contributetorockstor` or :ref:`contributedocs`.
+If you are familiar with git then working on an issue branch in a local clone of your GitHub fork is favoured.
+If you are not then the following is a quick and easy method but far less flexible.
 
-1. Creating an *issue* in the **rockon-registry** repository.
-2. Creating your own *fork* of the **rockon-registry**.
-3. Create a *new branch* dedicated to the issue you just created (ideally containing the 
-   issue #).
-4. Write your Rock-on JSON definition file following the `README.md <https://github.com/rockstor/rockon-registry/blob/master/README.md>`_ 
-   as guideline.
-5. Once you're finished writing and testing your new Rock-on definition file, upload it 
-   to this branch.
-6. Submit a *pull-request* to the **rockon-registry** repository. 
+A GitHub account is required.
+
+1. Create a *New issue* (button) in the **rockon-registry** `issues section <https://github.com/rockstor/rockon-registry/issues>`_ and explain what you are proposing.
+2. Creating your own *Fork* (button) of the `rockon-registry <https://github.com/rockstor/rockon-registry>`_ (GitHub login required).
+3. Write and test your Rock-on definition file following the `README.md <https://github.com/rockstor/rockon-registry/blob/master/README.md>`_.
+4. In your forked copy on GitHub select **create new file** (button) and paste your JSON file and name it (no spaces).
+5. Before **Commit new file** (button) ensure  **"Create a new branch for this commit and start a pull request..."** is selected.
+6. After the selection in 5. change the suggested branch name to e.g. **"#1234 Add project Y as Rock-on"** where the number is that of your issue.
+
+You are then ready to **Propose new file** (button). Please then read and edit the presented pull request appropriately. And you can always edit it later.
 
 Which Docker image should I use?
 --------------------------------
@@ -50,3 +52,20 @@ the following guidelines can help:
   user intervention at the command line before and/or after.
 * Finally, the image size is another helpful factor, with smaller images being 
   usually favored.
+
+.. _deleterockons:
+
+Deleting a Rock-on
+==================
+
+The Rock-ons repository is predominantly community maintained / lead.
+As such we depend on community involvement to maintain it's health.
+On occasions a Rock-on will fall into dis-repair.
+If you find such a Rock-on, ie broken or build on an abandoned/deprecated docker image,
+then please report this on our `friendly forum <https://forum.rockstor.com/>`_.
+If there is then no community will/effort to maintain/repair that rock-on then we will happily accept a pull request to delete it.
+Such a pull request would include the removal/deletion of the associated JSON definition file and it's associated entry within the root.json file.
+Please reference the relevant forum discussion upon submitting such a pull request and limit each such Rock-on delete request to a single Rock-on.
+Such 'weeding' is definitely encouraged and contributes to the overall health of this repository and the project as a whole.
+It's always frustrating to find something broken and if the community will is not there to repair it then it's best removed.
+We have in the past neglected to stress this side of the community maintenance 'feedback' and are now moving to actively encourage this much needed 'weeding'.

--- a/contribute_rockons.rst
+++ b/contribute_rockons.rst
@@ -58,7 +58,7 @@ the following guidelines can help:
 Deleting a Rock-on
 ==================
 
-The Rock-ons repository is predominantly community maintained / lead.
+The Rock-ons repository is predominantly community maintained/led.
 As such we depend on community involvement to maintain it's health.
 On occasions a Rock-on will fall into dis-repair.
 If you find such a Rock-on, ie broken or build on an abandoned/deprecated docker image,

--- a/docker-based-rock-ons/overview.rst
+++ b/docker-based-rock-ons/overview.rst
@@ -83,9 +83,9 @@ Adding your own Rock-on
 
 The `rockon-registry <https://github.com/rockstor/rockon-registry>`_ contains
 the current list of freely available rock-on definition files and servers
-as the repository for :ref:`rockons_available`. Please consider donating,
-or asking your favourite project to donate, a rock-on via a GitHub pull request
-to this repository (see :ref:`contributerockons` for more information). Note 
+as the repository for :ref:`rockons_available`. Please consider contributing,
+or asking your favourite project to contribute, a rock-on via a GitHub pull request
+to this repository (see :ref:`contributerockons` for more information). Note
 that it is also possible to add to the available Rock-ons by placing a suitably 
 configured and named json file in the */opt/rockstor/rockons-metastore* directory 
 of your Rockstor install. For full instructions and examples please see the 


### PR DESCRIPTION
Fixes #238

## See issue text for proposal details.

## Includes:
- Moving to a GitHub Web-UI only method of Rock-on submission as we have already referenced in this same section our other more detailed and command line driven pull request submission methods.
- Text to stress that there are limitations to a GitHub Web-UI only approach and that a command line approach is more flexible.
- Addition of a new "Deleting a Rock-on" section containing explanations of the community involvement in the 'weeding' process to remove defunct Rock-ons.
- Normalise on 'contribute' and remove 'donate'.
- A move, in the changed sections, towards using punctuation as line breaks within the original formatting. This can help to ease future pull request reviews and make for easier reading/editing.

@FroggyFlox Ready for review.

The resulting html formatting was as expected in recent versions of both FireFox and Chrome.

### Checklist
- [x] With the proposed changes no Sphinx errors or warnings are generated.
- [x] I have added my name to the AUTHORS file, if required (descending alphabetical order).