### PR TITLE
Add usage of docker-sphinx

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -14,6 +14,7 @@ lifton
 Jon Wilson
 HBDK
 Gompa
+George Andrei
 FroggyFlox
 Fantastitech
 Dorian Bivolaru

--- a/contribute_documentation.rst
+++ b/contribute_documentation.rst
@@ -23,29 +23,29 @@ look cool.
 
 .. code-block:: bash
 
-	[you@your_laptop ~/projects]# git clone git@github.com:your_github_username/rockstor-doc.git
+        [you@your_laptop ~/projects]# git clone git@github.com:your_github_username/rockstor-doc.git
 
 The above command creates a local **rockstor-doc** git repo in a new directory
 by the same name(rockstor-doc). Change into it.
 
 .. code-block:: bash
 
-	[you@your_laptop ~/projects]# cd rockstor-doc
+        [you@your_laptop ~/projects]# cd rockstor-doc
 
 Configure this new git repo with your name and email address. This is required
 to accurately record collaboration.
 
 .. code-block:: bash
 
-	[you@your_laptop rockstor-doc]# git config user.name "Firstname Lastname"
-	[you@your_laptop rockstor-doc]# git config user.email your_email_address
+        [you@your_laptop rockstor-doc]# git config user.name "Firstname Lastname"
+        [you@your_laptop rockstor-doc]# git config user.email your_email_address
 
 Add a remote called upstream to periodically rebase your local repository with
 changes in the upstream made by other contributors.
 
 .. code-block:: bash
 
-	[you@your_laptop rockstor-doc]# git remote add upstream https://github.com/rockstor/rockstor-doc.git
+        [you@your_laptop rockstor-doc]# git remote add upstream https://github.com/rockstor/rockstor-doc.git
 
 
 Making changes
@@ -61,21 +61,21 @@ branch with the upstream.
 
 .. code-block:: bash
 
-	[you@your_laptop rockstor-doc]# git checkout master
-	[you@your_laptop rockstor-doc]# git pull --rebase upstream master
+        [you@your_laptop rockstor-doc]# git checkout master
+        [you@your_laptop rockstor-doc]# git pull --rebase upstream master
 
 Checkout a new/separate branch for your issue. For example:
 
 .. code-block:: bash
 
-	[you@your_laptop rockstor-doc]# git checkout -b issue#1234_brief_label
+        [you@your_laptop rockstor-doc]# git checkout -b issue#1234_brief_label
 
 You can then start making changes in this branch. Once done you can add your
 changes.
 
 .. code-block:: bash
 
-	[you@your_laptop rockstor-doc]# git add new_file_added.rst existing_file.rst
+        [you@your_laptop rockstor-doc]# git add new_file_added.rst existing_file.rst
 
 
 We strongly encourage you to commit changes a certain way to help other
@@ -86,7 +86,7 @@ independent commits.
 
 .. code-block:: bash
 
-	[you@your_laptop rockstor-doc]# git commit new_file_added.rst existing_file.rst
+        [you@your_laptop rockstor-doc]# git commit new_file_added.rst existing_file.rst
 
 We request that you divide a commit message into three parts. Start the message
 with a single line summary, about 50-70 characters in length. Add a blank line
@@ -97,19 +97,19 @@ a fictional example:
 
 .. code-block:: bash
 
-	foobar functionality documentation for rockstor
+        foobar functionality documentation for rockstor
 
-	This document describes foobar functionality. This feature is based on algorithm called
-	recursive transaction launcher to generate transactional foobars.
+        This document describes foobar functionality. This feature is based on algorithm called
+        recursive transaction launcher to generate transactional foobars.
 
-	# Please enter the commit message for your changes. Lines starting
-	# with '#' will be ignored, and an empty message aborts the commit.
-	# On branch issue#1234_test
-	# Changes to be committed:
-	#   (use "git reset HEAD <file>..." to unstage)
-	#
-	#       new file:   foobar.py
-	#
+        # Please enter the commit message for your changes. Lines starting
+        # with '#' will be ignored, and an empty message aborts the commit.
+        # On branch issue#1234_test
+        # Changes to be committed:
+        #   (use "git reset HEAD <file>..." to unstage)
+        #
+        #       new file:   foobar.py
+        #
 
 If you'd like credit for your patch or if you are a frequent contributor, you
 should add your name to the `rockstor-doc AUTHORS
@@ -143,13 +143,13 @@ For a **Python 2** installation, use these commands.
 
 .. code-block:: bash
 
-	[you@your_laptop /path/to/rockstor-doc]# sudo pip install --user sphinxcontrib-fulltoc
+        [you@your_laptop /path/to/rockstor-doc]# sudo pip install --user sphinxcontrib-fulltoc
 
 For a **Python 3** installation, favoured, use these commands.
 
 .. code-block:: bash
 
-	[you@your_laptop /path/to/rockstor-doc]# sudo pip3 install --user sphinxcontrib-fulltoc
+        [you@your_laptop /path/to/rockstor-doc]# sudo pip3 install --user sphinxcontrib-fulltoc
 
 
 Using Sphinx as a Docker container
@@ -162,16 +162,16 @@ This can be easily done by creating a simple :code:`Dockerfile` containing this:
 
 .. code-block:: Dockerfile
 
-	FROM sphinxdoc/sphinx
+        FROM sphinxdoc/sphinx
 
-	WORKDIR /docs
-	RUN pip3 install sphinxcontrib-fulltoc
+        WORKDIR /docs
+        RUN pip3 install sphinxcontrib-fulltoc
 
 Now you can just build the container with this command:
 
 .. code-block:: bash
 
-	[you@your_laptop /path/to/sphinx-rockstor]# docker build -t sphinx-rockstor .
+        [you@your_laptop /path/to/sphinx-rockstor]# docker build -t sphinx-rockstor .
 
 Generating html files with Sphinx
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -181,13 +181,13 @@ following command :
 
 .. code-block:: bash
 
-	[you@your_laptop /path/to/rockstor-doc]# make html
+        [you@your_laptop /path/to/rockstor-doc]# make html
 
 If you use :code:`docker-sphinx` you can use the following command:
 
 .. code-block:: bash
 
-	[you@your_laptop /path/to/rockstor-doc]# docker run --rm -v $PWD:/docs sphinx-rockstor make html
+        [you@your_laptop /path/to/rockstor-doc]# docker run --rm -v $PWD:/docs sphinx-rockstor make html
 
 HTML files are generated in _build/html directory. From a separate terminal
 window, you can have a simple Python webserver always serving up this content
@@ -197,13 +197,13 @@ For a **Python 2** installation, use the following command.
 
 .. code-block:: bash
 
-	[you@your_laptop /path/to/rockstor-doc/_build/html]# python -m SimpleHTTPServer 8000
+        [you@your_laptop /path/to/rockstor-doc/_build/html]# python -m SimpleHTTPServer 8000
 
 For a **Python 3** installation, use the following command.
 
 .. code-block:: bash
 
-	[you@your_laptop /path/to/rockstor-doc/_build/html]# python -m http.server 8000
+        [you@your_laptop /path/to/rockstor-doc/_build/html]# python -m http.server 8000
 
 You can now go to :code:`http://localhost:8000` in your browser to review your
 changes. The webserver is to be started only once and it will continue to serve
@@ -221,8 +221,8 @@ following command:
 
 .. code-block:: bash
 
-	[you@your_laptop ]# cd /path/to/rockstor-doc
-	[you@your_laptop rockstor-doc]# git push origin your_branch_name
+        [you@your_laptop ]# cd /path/to/rockstor-doc
+        [you@your_laptop rockstor-doc]# git push origin your_branch_name
 
 When you finish work for the issue and are ready to submit, create a pull
 request by clicking on the **pull request** button on github. This notifies the

--- a/contribute_documentation.rst
+++ b/contribute_documentation.rst
@@ -19,25 +19,33 @@ on the **Fork** button. This will fork the repository into your profile which
 serves as your private git remote called origin. The next few git steps are
 demonstrated on a Linux terminal. They work the same on a Mac too. Your IDE may
 have ways to completely avoid the terminal, but using the terminal makes you
-look cool. ::
+look cool.
+
+.. code-block:: bash
 
 	[you@your_laptop ~/projects]# git clone git@github.com:your_github_username/rockstor-doc.git
 
 The above command creates a local **rockstor-doc** git repo in a new directory
-by the same name(rockstor-doc). Change into it. ::
+by the same name(rockstor-doc). Change into it.
+
+.. code-block:: bash
 
 	[you@your_laptop ~/projects]# cd rockstor-doc
 
 Configure this new git repo with your name and email address. This is required
-to accurately record collaboration. ::
+to accurately record collaboration.
+
+.. code-block:: bash
 
 	[you@your_laptop rockstor-doc]# git config user.name "Firstname Lastname"
 	[you@your_laptop rockstor-doc]# git config user.email your_email_address
 
 Add a remote called upstream to periodically rebase your local repository with
-changes in the upstream made by other contributors. ::
+changes in the upstream made by other contributors.
 
-	[you@your_laptop rockstor-doc]#git remote add upstream https://github.com/rockstor/rockstor-doc.git
+.. code-block:: bash
+
+	[you@your_laptop rockstor-doc]# git remote add upstream https://github.com/rockstor/rockstor-doc.git
 
 
 Making changes
@@ -49,17 +57,23 @@ want to document something for which there is no issue, feel free to create
 one.
 
 First, start with the latest documentation by rebasing your local repo's master
-branch with the upstream. ::
+branch with the upstream.
 
-        [you@your_laptop rockstor-doc]# git checkout master
-        [you@your_laptop rockstor-doc]# git pull --rebase upstream master
+.. code-block:: bash
 
-Checkout a new/separate branch for your issue. For example::
+	[you@your_laptop rockstor-doc]# git checkout master
+	[you@your_laptop rockstor-doc]# git pull --rebase upstream master
 
-        [you@your_laptop rockstor-doc]# git checkout -b issue#1234_brief_label
+Checkout a new/separate branch for your issue. For example:
+
+.. code-block:: bash
+
+	[you@your_laptop rockstor-doc]# git checkout -b issue#1234_brief_label
 
 You can then start making changes in this branch. Once done you can add your
-changes. ::
+changes.
+
+.. code-block:: bash
 
 	[you@your_laptop rockstor-doc]# git add new_file_added.rst existing_file.rst
 
@@ -68,7 +82,9 @@ We strongly encourage you to commit changes a certain way to help other
 contributors and keep the merge process smooth. Below guidelines are more
 pertinent to code contributions, but feel free to be as perfect as you like. As
 a guiding principle, separate your changes into one or more logically
-independent commits. ::
+independent commits.
+
+.. code-block:: bash
 
 	[you@your_laptop rockstor-doc]# git commit new_file_added.rst existing_file.rst
 
@@ -77,20 +93,22 @@ with a single line summary, about 50-70 characters in length. Add a blank line
 after that. If you want to add more than a summary to your commit message,
 describe the change in more detail in plain text format where each line is no
 more than 80 characters. This description should be in present tense. Below is
-a fictional example::
+a fictional example:
 
-        foobar functionality documentation for rockstor
+.. code-block:: bash
 
-        This document describes foobar functionality. This feature is based on algorithm called
+	foobar functionality documentation for rockstor
+
+	This document describes foobar functionality. This feature is based on algorithm called
 	recursive transaction launcher to generate transactional foobars.
 
-        # Please enter the commit message for your changes. Lines starting
-        # with '#' will be ignored, and an empty message aborts the commit.
-        # On branch issue#1234_test
-        # Changes to be committed:
-        #   (use "git reset HEAD <file>..." to unstage)
-        #
-        #       new file:   foobar.py
+	# Please enter the commit message for your changes. Lines starting
+	# with '#' will be ignored, and an empty message aborts the commit.
+	# On branch issue#1234_test
+	# Changes to be committed:
+	#   (use "git reset HEAD <file>..." to unstage)
+	#
+	#       new file:   foobar.py
 	#
 
 If you'd like credit for your patch or if you are a frequent contributor, you
@@ -121,33 +139,71 @@ to check your work, you'll need these packages for the make to complete successf
 If you are generating videos, and prefer uploading your videos to the Rockstor Youtube channel,
 please, send an email to support@rockstor.com
 
-For a **Python 2** installation, use these commands. ::
+For a **Python 2** installation, use these commands.
+
+.. code-block:: bash
 
 	[you@your_laptop /path/to/rockstor-doc]# sudo pip install --user sphinxcontrib-fulltoc
-	
-For a **Python 3** installation, favoured, use these commands.  ::
+
+For a **Python 3** installation, favoured, use these commands.
+
+.. code-block:: bash
 
 	[you@your_laptop /path/to/rockstor-doc]# sudo pip3 install --user sphinxcontrib-fulltoc
-	
+
+
+Using Sphinx as a Docker container
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Sphinx can also be used as a docker container, without needing to install it on your computer.
+But the base image `docker-sphinx <https://github.com/sphinx-doc/docker>`_ doesn't contain **sphinxcontrib-fulltoc** which is needed by Rockstor documentation,
+in order to add this package, you must build your own docker image.
+This can be easily done by creating a simple :code:`Dockerfile` containing this:
+
+.. code-block:: Dockerfile
+
+	FROM sphinxdoc/sphinx
+
+	WORKDIR /docs
+	RUN pip3 install sphinxcontrib-fulltoc
+
+Now you can just build the container with this command:
+
+.. code-block:: bash
+
+	[you@your_laptop /path/to/sphinx-rockstor]# docker build -t sphinx-rockstor .
+
 Generating html files with Sphinx
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 As you edit the content in .rst files, you can periodically generate html files
 and review them in your browser. To generate or update the HTML files, use the
-following command ::
+following command :
 
-        [you@your_laptop /path/to/rockstor-doc]# make html
+.. code-block:: bash
+
+	[you@your_laptop /path/to/rockstor-doc]# make html
+
+If you use :code:`docker-sphinx` you can use the following command:
+
+.. code-block:: bash
+
+	[you@your_laptop /path/to/rockstor-doc]# docker run --rm -v $PWD:/docs sphinx-rockstor make html
 
 HTML files are generated in _build/html directory. From a separate terminal
 window, you can have a simple Python webserver always serving up this content
 with one of the following commands:
 
-For a **Python 2** installation, use the following command. ::
+For a **Python 2** installation, use the following command.
 
-        [you@your_laptop /path/to/rockstor-doc/_build/html]# python -m SimpleHTTPServer 8000
+.. code-block:: bash
 
-For a **Python 3** installation, use the following command. ::
+	[you@your_laptop /path/to/rockstor-doc/_build/html]# python -m SimpleHTTPServer 8000
 
-        [you@your_laptop /path/to/rockstor-doc/_build/html]# python -m http.server 8000
+For a **Python 3** installation, use the following command.
+
+.. code-block:: bash
+
+	[you@your_laptop /path/to/rockstor-doc/_build/html]# python -m http.server 8000
 
 You can now go to :code:`http://localhost:8000` in your browser to review your
 changes. The webserver is to be started only once and it will continue to serve
@@ -161,10 +217,12 @@ the steps outlined here, you can open a pull request.
 
 As you continue to work on an issue, commit and push changes to the issue
 branch of your fork.  You can periodically push your changes to github with the
-following command::
+following command:
+
+.. code-block:: bash
 
 	[you@your_laptop ]# cd /path/to/rockstor-doc
-	[you@your_laptop rockstor-doc] git push origin your_branch_name
+	[you@your_laptop rockstor-doc]# git push origin your_branch_name
 
 When you finish work for the issue and are ready to submit, create a pull
 request by clicking on the **pull request** button on github. This notifies the


### PR DESCRIPTION

Fixes #272 

### This pull request's proposal

- Add documentation about usage of docker-sphinx
- Add `code-block` type

### Checklist
- [x] With the proposed changes no Sphinx errors or warnings are generated.
- [x] I have added my name to the AUTHORS file, if required (descending alphabetical order).

### Sphinx output
sphinx-build -b html -d _build/doctrees   . _build/html
Running Sphinx v3.5.0
loading pickled environment... done
building [mo]: targets for 0 po files that are out of date
building [html]: targets for 0 source files that are out of date
updating environment: 0 added, 0 changed, 0 removed
looking for now-outdated files... none found
no targets are out of date.
build succeeded.

The HTML pages are in _build/html.

Build finished. The HTML pages are in _build/html.
