### PR TITLE
Add Github workflow to run sphinx's checks on PR creation (#279)

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -1,0 +1,28 @@
+name: "Sphinx checks on pull-request"
+on:
+- pull_request
+
+jobs:
+  build_docs:
+    runs-on: ubuntu-latest
+    steps:
+    - name: checkout source code
+      uses: actions/checkout@v2
+    - name: install sphinx
+      run: pip3 install -U sphinx
+    - name: install sphinxcontrib-fulltoc
+      run: pip3 install sphinxcontrib-fulltoc
+    - name: build docs
+      run: make html
+
+  linkcheck:
+    runs-on: ubuntu-latest
+    steps:
+    - name: checkout source code
+      uses: actions/checkout@v2
+    - name: install sphinx
+      run: pip3 install -U sphinx
+    - name: install sphinxcontrib-fulltoc
+      run: pip3 install sphinxcontrib-fulltoc
+    - name: check links
+      run: make linkcheck


### PR DESCRIPTION
Fixes #279 
@phillxnet, ready for review.

### This pull request's proposal
This pull request (PR) proposes to add a simple Github workflow to run sphinx's `make html` and `make linkcheck` on each PR creation.

A couple points of interest:
- it runs on the latest Ubuntu Github runner
- it uses the latest `sphinx` and `sphinxcontrib-fulltoc` packages from PyPI so it ensures we're always checking with an up-to-date version of Sphinx.

### Checklist
- [x] With the proposed changes no Sphinx errors or warnings are generated.
- [x] I have added my name to the AUTHORS file, if required (descending alphabetical order).