### PR TITLE
Fix broken links (#278)

### DIFF
--- a/afp/apple_filing_protocol.rst
+++ b/afp/apple_filing_protocol.rst
@@ -1,7 +1,7 @@
 .. raw:: html
 
    <div class="alert alert-warning">
-   <strong>Note:</strong> Following the loss of support for AFP in newer macOS versions, the AFP service is no longer supported as of Rockstor-3.9.2-56. We thus recommend users to use the <a href="http://rockstor.com/docs/samba_ops.html#samba" target="_blank">Samba service</a> instead (see <a href="https://forum.rockstor.com/t/3-9-2-stable-channel-changelog/5741/22" target="_blank">this forum post</a> for details).
+   <strong>Note:</strong> Following the loss of support for AFP in newer macOS versions, the AFP service is no longer supported as of Rockstor-3.9.2-56. We thus recommend users to use the <a href="https://rockstor.com/docs/samba_ops.html#samba" target="_blank">Samba service</a> instead (see <a href="https://forum.rockstor.com/t/3-9-2-stable-channel-changelog/5741/22" target="_blank">this forum post</a> for details).
    </div>
 
 ..  _afp:

--- a/analytics.rst
+++ b/analytics.rst
@@ -4,7 +4,7 @@
 Analytics
 =========
 
-We invite suggestions on `Our Community Forum <http://forum.rockstor.com/>`_ as
+We invite suggestions on `Our Community Forum <https://forum.rockstor.com/>`_ as
 to what else would be most useful on the **Analytics** page of Rockstor's WebUI.
 
 We hope to further detail existing NFS analytics in the near future.

--- a/conf.py
+++ b/conf.py
@@ -261,3 +261,7 @@ texinfo_documents = [
 
 # If true, do not generate a @detailmenu in the "Top" node's menu.
 #texinfo_no_detailmenu = False
+
+# -- Options for linkcheck ------------------------------------------------
+linkcheck_retries = 2
+linkcheck_timeout = 20

--- a/config_backup/config_backup.rst
+++ b/config_backup/config_backup.rst
@@ -6,7 +6,7 @@ Configuration Backup and Restore
 **Please note that this feature is in beta testing and not yet recommended
 for production use**
 
-*Bug reports or suggestions are always welcome on* `our forum <http://forum.rockstor.com/>`_
+*Bug reports or suggestions are always welcome on* `our forum <https://forum.rockstor.com/>`_
 
 The current configuration of Rockstor can be saved at any time and restored to
 any previously saved point.  This is a particularly useful feature when making

--- a/contribute.rst
+++ b/contribute.rst
@@ -15,7 +15,7 @@ Non developers
 
 There is a lot you can do other than coding that is essential to the
 project. First, please join our `community discussion forum
-<http://forum.rockstor.com>`_. It's the central location where all discussions
+<https://forum.rockstor.com>`_. It's the central location where all discussions
 take place. If you need help, want to share an idea, suggest a new feature etc..
 the forum is a great place to start. Being active on the forum is very helpful
 to the project and the community as a whole.
@@ -42,14 +42,14 @@ Developing Rockstor to deliver on its unique value proposition of being a
 Smart, Powerful, and Open storage platform is a major effort. If you are
 passionate about Open Source and Storage like us, you are in the right
 company. We welcome you to join our community. Please begin by joining our
-`community discussion forum <http://forum.rockstor.com>`_.
+`community discussion forum <https://forum.rockstor.com>`_.
 
 Our development process is simple and straight forward. There is currently one
 main repository called `rockstor-core on Github
 <https://github.com/rockstor/rockstor-core>`_. Begin by `forking it
 <https://github.com/rockstor/rockstor-core/fork>`_.
 
-We use the wonderful `Git <http://git-scm.com/>`_ for source code
+We use the wonderful `Git <https://git-scm.com/>`_ for source code
 management and `Rockstor on Github <https://github.com/rockstor>`_ for issue
 tracking. We'll assume you have basic proficiency with Git and are familiar
 with it using a text editor or IDE of your choice. Emacs, Vim,
@@ -66,7 +66,7 @@ Tracker <https://github.com/rockstor/rockstor-core/issues>`_.
 .
 
 3. Submit your changes in a single `pull request
-<https://help.github.com/articles/using-pull-requests>`_.
+<https://docs.github.com/en/github/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests>`_.
 
 4. Use the issue tracker for discussions as necessary
 .
@@ -277,7 +277,7 @@ rockstor.log should be the first place to look for errors or debug logs.
 
 When making frontend changes, Developer Tools in Chrome/Firefox are your
 friends. You can `inspect elements
-<https://developers.google.com/web/tools/chrome-devtools/dom>`_
+<https://developer.chrome.com/docs/devtools/dom/>`_
 for html/css changes, log to the browser console from javascript code with
 console.log(), and use the debugger and step through javascript from your
 browser.
@@ -311,13 +311,13 @@ pull-request process is same as it is for this(rockstor-core repo) one.
 Database migrations
 -------------------
 
-We use `PostgreSQL <http://www.postgresql.org/>`_ as the database backend for
+We use `PostgreSQL <https://www.postgresql.org/>`_ as the database backend for
 Rockstor. There are two databases, (1) storageadmin and (2)
 smart_manager. Depending on your issue you may need to add a Django model,
 delete one, or change fields of an existing model. After editing models you
 need to create a migration and apply it.
 
-We used `South <http://south.aeracode.org/>`_ to manage database migrations for
+We used `South <https://south.aeracode.org/>`_ to manage database migrations for
 a while, but since updating to Django 1.8, migrations are natively
 supported. The steps have changed only slightly. Generate the migration on your
 VM and copy the migration file back to your laptop and add it in git once you
@@ -369,7 +369,7 @@ search for a change or track a regression.
 
 Squashing commits into one is straight forward and most editors and IDEs with
 git support make it super easy to do so. If you've never done this before, this
-`short how-to <https://ariejan.net/2011/07/05/git-squash-your-latests-commits-into-one/>`_ is
+`short how-to <https://levelup.gitconnected.com/how-to-squash-git-commits-9a095c1bc1fc>`_ is
 helpful.
 
 Contributing and testing from another Rockstor contributor fork

--- a/contribute_documentation.rst
+++ b/contribute_documentation.rst
@@ -205,7 +205,7 @@ For a **Python 3** installation, use the following command.
 
         [you@your_laptop /path/to/rockstor-doc/_build/html]# python -m http.server 8000
 
-You can now go to :code:`https://localhost:8000` in your browser to review your
+You can now go to :code:`http://localhost:8000` in your browser to review your
 changes. The webserver is to be started only once and it will continue to serve
 the files and changes you make to them.
 

--- a/contribute_documentation.rst
+++ b/contribute_documentation.rst
@@ -117,7 +117,7 @@ should add your name to the `rockstor-doc AUTHORS
 
 
 Unlike for code contributions, there is no need for a build VM. We use `Sphinx
-<http://www.sphinx-doc.org>`_ to generate the html content from .rst
+<https://www.sphinx-doc.org>`_ to generate the html content from .rst
 files we edit. Installation procedure varies if you are on Mac, Windows, or Linux, so
 follow the appropriate installation guide for Sphinx.
 
@@ -126,8 +126,8 @@ Installing Sphinx
 ^^^^^^^^^^^^^^^^^
 In order to properly develop and submit contributions you'll need to install Sphinx, plus one Sphinx extension
 
-`Sphinx official documentation <http://www.sphinx-doc.org/en/master/#>`_ gives guidelines for installating Sphinx on various platforms.
-Details of how to install Sphinx is covered in their  `Installing Spinx <http://www.sphinx-doc.org/en/master/usage/installation.html>`_ documentation.
+`Sphinx official documentation <https://www.sphinx-doc.org/en/master/#>`_ gives guidelines for installating Sphinx on various platforms.
+Details of how to install Sphinx is covered in their  `Installing Spinx <https://www.sphinx-doc.org/en/master/usage/installation.html>`_ documentation.
 
 Once you have Sphinx installed you'll need 1 more Sphinx extensions before you're fully ready.
 The sphinxcontrib-fulltoc package, generates the sidebar table of contents.
@@ -205,7 +205,7 @@ For a **Python 3** installation, use the following command.
 
         [you@your_laptop /path/to/rockstor-doc/_build/html]# python -m http.server 8000
 
-You can now go to :code:`http://localhost:8000` in your browser to review your
+You can now go to :code:`https://localhost:8000` in your browser to review your
 changes. The webserver is to be started only once and it will continue to serve
 the files and changes you make to them.
 
@@ -231,7 +231,13 @@ issue containing all relevant changes.
 
 When you are ready, open the pull request and please follow these 2 tips to expedite the review:
 
-    * When you've finished your edit, run the Sphinx *make html* command, and paste its output into the pull request discussion string to help speed up the review.  After you've generated the html, you can use the webserver detailed above to check the functionality of your work prior to your pull request
+* When you've finished your edit, run the Sphinx :code:`make html` command, and
+  paste its output into the pull request discussion string to help speed up the
+  review. After you've generated the html, you can use the webserver detailed
+  above to check the functionality of your work prior to your pull request.
 
-
-    * When you make a pull request, adding a "Fixes #number-of-issue" on its own line will automatically close the related issue when it gets merged. Just a nice thing to have and also provides a link to the relevant issue. See https://help.github.com/articles/closing-issues-using-keywords/ for details.
+* When you make a pull request, adding a "Fixes #number-of-issue" on its own
+  line will automatically close the related issue when it gets merged. Just a
+  nice thing to have and also provides a link to the relevant issue. See
+  `GitHub documentation <https://docs.github
+  .com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue>`_ for details.

--- a/docker-based-rock-ons/discourse.rst
+++ b/docker-based-rock-ons/discourse.rst
@@ -8,7 +8,7 @@ Please be aware of the common prerequisites for all Rockstor :ref:`rockons_intro
 specifically the :ref:`rockons_preinstall` and :ref:`rockons_root`
 requirement.
 
-Our `Discourse Rock-on forum <http://forum.rockstor.com/t/discourse-rock-on/941>`_ area.
+Our `Discourse Rock-on forum <https://forum.rockstor.com/t/discourse-rock-on/941>`_ area.
 
 .. _discourse_whatis:
 
@@ -16,15 +16,15 @@ What is Discourse
 -----------------
 
 Discourse is open source forum / discussion server software and is what the
-`Rockstor forum <http://forum.rockstor.com/>`_ itself uses; in fact Rockstor's
+`Rockstor forum <https://forum.rockstor.com/>`_ itself uses; in fact Rockstor's
 forum is in fact hosted as a Rock-on on a Rockstor system. It is available in
 `17 languages and counting
 <https://www.transifex.com/discourse/discourse-org/>`_ and supports such
 features as `single sign on
-<https://meta.discourse.org/t/official-single-sign-on-for-discourse/13045>`_
+<https://meta.discourse.org/t/discourseconnect-official-single-sign-on-for-discourse-sso/13045>`_
 and real time notifications. The source code for Discourse is available on `the
 Discourse GitHub Page <https://github.com/discourse/discourse>`_. Visit the
-Discourse `online sandbox <http://try.discourse.org/>`_ for a demonstration.
+Discourse `online sandbox <https://try.discourse.org/>`_ for a demonstration.
 
 .. _discourse_doc:
 
@@ -32,7 +32,7 @@ Discourse Documentation
 -----------------------
 
 Discourse's `About Page <https://www.discourse.org/about/>`_ is a good place to
-start along with their `FAQ <https://www.discourse.org/faq/>`_ and their
+start along with their `FAQ <https://www.discourse.org/about>`_ and their
 `Blog <https://blog.discourse.org/>`_.
 
 .. _discourse_install:

--- a/docker-based-rock-ons/jenkins.rst
+++ b/docker-based-rock-ons/jenkins.rst
@@ -7,7 +7,7 @@ Please be aware of the common prerequisites for all Rockstor :ref:`rockons_intro
 specifically the :ref:`rockons_preinstall` and :ref:`rockons_root`
 requirement.
 
-Our `Jenkins Rock-on forum <http://forum.rockstor.com/t/jenkins-rock-on/947>`_
+Our `Jenkins Rock-on forum <https://forum.rockstor.com/t/jenkins-rock-on/947>`_
 area.
 
 .. _jenkins_whatis:
@@ -15,32 +15,28 @@ area.
 What is Jenkins
 -----------------
 
-`Jenkins, <https://jenkins-ci.org/>`_ previously known as *Hudson*, is an
+`Jenkins, <https://www.jenkins.io/>`_ previously known as *Hudson*, is an
 `MIT Licenced <https://github.com/jenkinsci/jenkins/blob/master/LICENSE.txt>`_
 open source automated testing and deployment system, ie a continuous integration
 and continuous delivery system. The idea is that such a system can be used
 to automate repetitive tasks such as those associated with testing and
 deployment. This reduces the possibility of human error and is aimed at
 increasing productivity and shortening the time to deploy fixes to production.
-The Rockstor organisation itself uses Jenkins and in the form of this very
-Rock-on running on Rockstor. Other currently more famous organisations :) that
-use Jenkin are; Dell, NASA, Netflix, and GitHub. A
+Famous organisations that use Jenkin are; Dell, NASA, Netflix, and GitHub. A
 `more extensive list
-<https://wiki.jenkins-ci.org/pages/viewpage.action?pageId=58001258>`_
-is available from the *Meet Jenkins* link that follows.
+<https://wiki.jenkins.io/pages/viewpage.action?pageId=58001258>`_
+is available from the Jenkins documentation linked below.
 
 .. _jenkins_doc:
 
 Jenkins Documentation
 -----------------------
 
-The `Meet Jenkins <https://wiki.jenkins-ci.org/display/JENKINS/Meet+Jenkins>`_
-page is a good place to start. There you will find a quick 'What is' a list of
-features, introductory articles, how to take a test drive via their Jave Web
-Start facility, install instructions, and the aforementioned list of
-organisations benefiting from Jenkins. See also the
-`Jenkins Blog <https://jenkins-ci.org/node/>`_ and
-`Jenkins Wiki <https://wiki.jenkins-ci.org/display/JENKINS/Home>`_ pages.
+The `Jenkins documentation <https://www.jenkins.io/>`_ page is a good place to
+start. There you will find a quick 'What is' a list of features, introductory
+articles, how to take a test drive via their Java Web Start facility, install
+instructions, and the aforementioned list of organisations benefiting from
+Jenkins. See also the `Jenkins Blog <https://www.jenkins.io/node/>`_ page.
 
 .. _jenkins_install:
 

--- a/docker-based-rock-ons/minio.rst
+++ b/docker-based-rock-ons/minio.rst
@@ -35,12 +35,12 @@ installation. This would violate the '"all-in-one" user experience' guideline in
 MinIO Documentation
 -----------------------
 
-If you want a deep dive into the full range of MinIO capabilities, the MinIO project 
-maintains extensive, well-written `documentation <https://docs.min.io/>`_ covering 
-many different deployment models.  You don't need to worry about all that to use this 
-Rock-on, though.  Simply point your MinIO-enabled client at the URL for your server 
-("http://domain-name:port") and use the Access Key (username) and Secret Key (password) 
-that you specified during installation.
+If you want a deep dive into the full range of MinIO capabilities, the MinIO
+project maintains extensive, well-written `documentation <https://docs.min.io/>`_
+covering many different deployment models.  You don't need to worry about all
+that to use this Rock-on, though.  Simply point your MinIO-enabled client at the
+URL for your server (``http://domain-name:port``) and use the Access Key
+(username) and Secret Key (password) that you specified during installation.
 
 
 .. _minio_install:

--- a/docker-based-rock-ons/openvpn-server.rst
+++ b/docker-based-rock-ons/openvpn-server.rst
@@ -7,7 +7,7 @@ Please be aware of the common prerequisites for all Rockstor :ref:`rockons_intro
 specifically the :ref:`rockons_preinstall` and :ref:`rockons_root`
 requirement.
 
-Our `OpenVPN server Rock-on forum <http://forum.rockstor.com/t/openvpn-server-rock-on/178>`_ area.
+Our `OpenVPN server Rock-on forum <https://forum.rockstor.com/t/openvpn-server-rock-on/178>`_ area.
 
 What is OpenVPN
 ---------------

--- a/docker-based-rock-ons/overview.rst
+++ b/docker-based-rock-ons/overview.rst
@@ -140,7 +140,7 @@ Although the following Rock-ons are currently without specific install
 instructions they are like all Rock-on installs, fairly self explanatory.
 
 * `Bitcoin <https://bitcoin.com/>`_: Bitcoin full node
-* `Bitwarden <https://github.com/dani-garcia/bitwarden_rs>`_: Unofficial server written in Rust for the password manager Bitwarden
+* `Bitwarden <https://github.com/dani-garcia/vaultwarden>`_: Unofficial server written in Rust for the password manager Bitwarden
 * `Booksonic <https://booksonic.org>`_: Audiobooks streaming server
 * `Cardigann <https://github.com/cardigann/cardigann>`_: A proxy server for adding new indexers to Sonarr and other media managers
 * `Collabora online <https://www.collaboraoffice.com/code/>`_: LibreOffice-based online office suite
@@ -148,7 +148,7 @@ instructions they are like all Rock-on installs, fairly self explanatory.
 * `CouchPotato <https://couchpota.to/>`_: Downloader for usenet and bittorrent users
 * `Crashplan <https://www.crashplan.com/en-us/>`_: Automatic cloud-based backups
 * `Deluge <https://deluge-torrent.org/>`_: Deluge is a movie downloader for bittorrent users
-* `Dropbox <https://dropbox.com>`_: Cloud-based file syncing solution
+* `Dropbox <https://www.dropbox.com>`_: Cloud-based file syncing solution
 * `Duck DNS <https://www.duckdns.org>`_: Free dynamic DNS service
 * `Duplicati 2.0 <https://www.duplicati.com>`_: Free backup software to store encrypted backups online
 * `ecoDMS <https://www.ecodms.de/index.php/en/>`_: Electronic Document Managing System
@@ -159,43 +159,43 @@ instructions they are like all Rock-on installs, fairly self explanatory.
 * `Gollum <https://github.com/gollum/gollum>`_: Gollum is a simple wiki system built on top of Git
 * `Haproxy <https://github.com/daniel-illi/docker-haproxy-letsencrypt/tree/rock-on>`_: Reliable, High Performance TCP/HTTP Load Balancer with letsencrypt integration
 * `Headphones <https://github.com/rembo10/headphones>`_: Automated music downloader for NZB and Torrent
-* `Home Assistant <https://home-assistant.io/>`_: Open-source home automation platform
+* `Home Assistant <https://www.home-assistant.io/>`_: Open-source home automation platform
 * `HTTP to HTTPS redirect <https://github.com/geldim/docker-https-redirect>`_: Access the Rockstor web UI without having to remember to type "https:"
 * `Jackett <https://github.com/Jackett/Jackett>`_: Proxy server for queries from apps such as Sonarr, CouchPotato, and Mylar
-* `JDownloader 2 <http://jdownloader.org/>`_: Free, open-source download management tool
-* `Koel <https://koel.phanan.net/>`_: Simple web-based personal audio streaming service
+* `JDownloader 2 <https://jdownloader.org/>`_: Free, open-source download management tool
+* `Koel <https://koel.dev/>`_: Simple web-based personal audio streaming service
 * `Lazy Librarian <https://lazylibrarian.gitlab.io>`_: Automated ebook downloader for NZB and Torrent
-* `Logitech Squeezebox <http://mysqueezebox.com/index/Home>`_: Server for Squeezebox Devices
+* `Logitech Squeezebox <https://mysqueezebox.com/index/Home>`_: Server for Squeezebox Devices
 * `MariaDB <https://mariadb.org/>`_: MariaDB, relational database management system
 * `Medusa <https://pymedusa.com>`_: Automatic video library manager for TV shows
 * `Minecraft <https://www.minecraft.net/en-us/>`_: Minecraft server
 * `Muximux <https://github.com/mescon/Muximux>`_: Lightweight portal to view & manage your HTPC apps
 * `Mylar <https://github.com/evilhero/mylar>`_: Automated Comic Book (cbr/cbz) downloader
-* `Nextcloud <https://www.nextcloud.com/>`_: Next generation open source enterprise file sync and share
-* `NZBGet <http://nzbget.net/>`_: The most efficient usenet downloader
+* `Nextcloud <https://nextcloud.com/>`_: Next generation open source enterprise file sync and share
+* `NZBGet <https://nzbget.net/>`_: The most efficient usenet downloader
 * `NZBHydra <https://github.com/theotherp/nzbhydra>`_: Meta search for NZB indexers
 * `Ombi <https://ombi.io/>`_: Host your own Plex Request and user management system
-* `OwnCloud-Official <https://owncloud.org/>`_: Secure file sharing and hosting
+* `OwnCloud-Official <https://owncloud.com/>`_: Secure file sharing and hosting
 * `Pi-hole <https://pi-hole.net/>`_: A black hole for Internet advertisements
-* `Plexpy <https://github.com/JonnyWong16/plexpy>`_: Python-based Plex usage tracker
 * `PocketMine <https://www.pocketmine.net/>`_: Server software for Minecraft: Pocket Edition
 * `Radarr <https://github.com/Radarr/Radarr>`_: Radarr is a PVR for Movies on Usenet and Torrents
 * `Resilio Synch <https://www.resilio.com/>`_: Fast, private file sharing for teams and individuals
 * `Rocket.Chat <https://rocket.chat/>`_: Open Source Chat Platform
-* `SaBnzbd <http://sabnzbd.org/>`_: The best usenet downloader
+* `SaBnzbd <https://sabnzbd.org/>`_: The best usenet downloader
 * `Seafile <https://www.seafile.com/>`_: Secure file sharing and hosting
-* `Sickbeard <http://sickbeard.com/>`_: Internet PVR for your TV shows, by Linuxserver.io
+* `Sickbeard <https://sickbeard.com/>`_: Internet PVR for your TV shows, by Linuxserver.io
 * `SmokePing <https://oss.oetiker.ch/smokeping/>`_: Network latency history monitor
 * `Sonarr <https://sonarr.tv/>`_: (formerly NZBdrone) A PVR for usenet and bittorrent users
 * `Subsonic <http://www.subsonic.org>`_: Music server
+* `Tautulli <https://github.com/Tautulli/Tautulli>`_: Plex usage tracker
 * `Teamspeak <https://teamspeak.com/en/>`_: VoIP software
 * `TFTP server <https://github.com/jumanjihouse/docker-tftp-hpa>`_: TFTP server
 * `Transmission with OpenVPN <https://haugene.github.io/docker-transmission-openvpn/>`_: Transmission torrent client with webUI while connecting to OpenVPN
-* `Ubuiquiti Unifi by Linuxserver.io <https://unifi-network.ui.com/>`_: Unifi Access Point controller, provided by Linuxserver.io
-* `Unifi Controller <https://unifi-network.ui.com/>`_: Unifi Access Point controller
-* `uTorrent <https://www.github.com/domibarton/docker-utorrent>`_: BitTorrent client
+* `Ubuiquiti Unifi by Linuxserver.io <https://ui.com/consoles//>`_: Unifi Access Point controller, provided by Linuxserver.io
+* `Unifi Controller <https://ui.com/consoles/>`_: Unifi Access Point controller
+* `uTorrent <https://github.com/domibarton/docker-utorrent>`_: BitTorrent client
 * `Watchtower <https://github.com/containrrr/watchtower>`_: A process for automating Docker container base image updates
-* `Xeoma <http://felenasoft.com/xeoma/>`_: Video surveillance
+* `Xeoma <https://felenasoft.com/xeoma/en>`_: Video surveillance
 * `Zabbix-XXL <https://github.com/monitoringartist/zabbix-xxl>`_: Network and application monitoring
 * `ZeroNet <https://zeronet.io>`_: Decentralized websites using Bitcoin crypto and the BitTorrent network
 

--- a/docker-based-rock-ons/owncloud.rst
+++ b/docker-based-rock-ons/owncloud.rst
@@ -7,20 +7,21 @@ Please be aware of the common prerequisites for all Rockstor :ref:`rockons_intro
 specifically the :ref:`rockons_preinstall` and :ref:`rockons_root`
 requirement.
 
-Our `ownCloud Rock-on forum <http://forum.rockstor.com/t/owncloud-rock-on/182>`_ area.
+Our `ownCloud Rock-on forum <https://forum.rockstor.com/t/owncloud-rock-on/182>`_ area.
 
 .. _owncloud_whatis:
 
 What is OwnCloud
 ----------------
 
-`OwnCloud <https://owncloud.org/>`_ is an Open Source self hosting general cloud services system that is
+`OwnCloud <https://owncloud.com/>`_ is an Open Source self hosting general
+cloud services system that is
 gaining popularity with those wishing to take greater control of their internet
-based services. It's `features <https://owncloud.org/features/>`_ include sync
+based services. It's `features <https://owncloud.com/features/>`_ include sync
 and share capabilities across devices and users with; files, contacts,
 calendars, a news reader, photos management etc.  Is also has a plugins
 capability so can be extended via ownCloud *apps*.
-An `online demo <https://demo.owncloud.org/>`_ is availalbe.
+An `online demo <https://demo.owncloud.org/login>`_ is availalbe.
 
 .. _owncloud_doc:
 
@@ -28,8 +29,8 @@ OwnCloud Documentation
 ----------------------
 
 OwnCloud's `own documentation page <https://doc.owncloud.org/>`_ is a good
-place to start, see also their `Get Started <https://owncloud.org/install/>`_
-page and their `FAQ <https://owncloud.org/faq/>`_. Take care to select the
+place to start, see also their `Get Started <https://owncloud
+.com/download-server/>`_ page and their `FAQ <https://owncloud.com/faq/>`_. Take care to select the
 appropriate documentation version appropriate to your install as ownCloud is
 rapidly developing. Rockstor 3.8-2 introduced our ownCloud Rock-on which on
 release installed version 8.0.4 of ownCloud. Since ownCloud is quite a large
@@ -73,7 +74,7 @@ Next we select the **Storage areas** for ownCloud's **data**,
 * **owncloud-db** - min 1 GB
 
 If you find that these values are insufficient then please discus this on the
-`Rockstor forum <http://forum.rockstor.com/t/owncloud-rock-on/182>`_ so that
+`Rockstor forum <https://forum.rockstor.com/t/owncloud-rock-on/182>`_ so that
 this document might be updated and improved.
 
 .. image:: owncloud_shares.png

--- a/docker-based-rock-ons/plex-media-server.rst
+++ b/docker-based-rock-ons/plex-media-server.rst
@@ -7,20 +7,22 @@ Please be aware of the common prerequisites for all Rockstor :ref:`rockons_intro
 specifically the :ref:`rockons_preinstall` and :ref:`rockons_root`
 requirement.
 
-Our `Plex Media Server Rock-on forum <http://forum.rockstor.com/t/plex-media-server-rock-on/179>`_ area.
+Our `Plex Media Server Rock-on forum <https://forum.rockstor.com/t/plex-media-server-rock-on/179>`_ area.
 
 .. _plex_whatis:
 
 What is Plex
 ------------
 
-`Plex <https://plex.tv/>`_ is a
-`centralized <https://support.plex.tv/hc/en-us/articles/200288286-What-is-Plex->`_
+`Plex <https://www.plex.tv/>`_ is a
+`centralized <https://support.plex.tv/articles/200288286-what-is-plex/>`_
 domestic media distribution system that acts
 both as a `DLNA <https://en.wikipedia.org/wiki/Digital_Living_Network_Alliance>`_
-server and as its own more `flexible <https://plex.tv/features>`_ type of
+server and as its own more `flexible <https://www.plex.tv/>`_ type of
 media server and client system.
-`Plex client apps <https://plex.tv/downloads>`_ are available on nearly
+`Plex client apps <https://www.plex.tv/media-server-downloads/>`_ are available
+on
+nearly
 every platform.  But in order to manage your media with the
 Plex system it is first necessary to have a
 **Plex Media Server**. This **Rock-on** is **exactly that**; and aims to make the install
@@ -31,7 +33,7 @@ and media provisioning of a Plex server as simple as possible.
 Plex Documentation
 ------------------
 
-Plex's `own documentation <https://support.plex.tv/hc/en-us>`_ is extensive and
+Plex's `own documentation <https://support.plex.tv/articles/>`_ is extensive and
 well presented and a good kicking off point might well be their `Getting Started
 <https://support.plex.tv/articles/200288286-what-is-plex/>`_ guide
 that has a thorough
@@ -88,7 +90,7 @@ non-admin non-root user ie *plex*.
 * **Data Storage** - room enough for your data and snapshots - minimum 100GB
 
 If you find that these values are insufficient then please discus this on the
-`Rockstor forum <http://forum.rockstor.com/t/plex-media-server-rock-on/179>`_
+`Rockstor forum <https://forum.rockstor.com/t/plex-media-server-rock-on/179>`_
 so that this document might be updated and improved.
 
 In the following image we are using the **recommended names** for all the
@@ -317,7 +319,7 @@ facilities available will vary according to your Plex web account status. If you
 do not already have a Plex account you can create one from within the PlexUI.
 
 Please see `Sign in to Your Plex Account
-<https://support.plex.tv/hc/en-us/articles/200878643-Sign-in-to-Your-Plex-Account>`_
+<https://support.plex.tv/articles/200878643-sign-in-to-your-plex-account/>`_
 for details.
 
 **Sign In** (with an existing Plex account) or **Sign Up** to remotely

--- a/docker-based-rock-ons/scrutiny.rst
+++ b/docker-based-rock-ons/scrutiny.rst
@@ -95,7 +95,8 @@ Here is a basic example for email notifications:
          - "smtp://mail@address.org:password@smtp.server.org:465/?fromAddress=mail@address.org&toAddresses=mail2@address.org"
 
 
-More information can be found on `Scrutiny GitHub <https://github.com/AnalogJ/scrutiny#configuration>`_
+More information can be found on `Scrutiny GitHub <https://github
+.com/AnalogJ/scrutiny#user-content-configuration>`_
 
 .. _scrutiny_install:
 

--- a/docker-based-rock-ons/syncthing.rst
+++ b/docker-based-rock-ons/syncthing.rst
@@ -7,7 +7,7 @@ Please be aware of the common prerequisites for all Rockstor :ref:`rockons_intro
 specifically the :ref:`rockons_preinstall` and :ref:`rockons_root`
 requirement.
 
-Our `Syncthing Rock-on forum <http://forum.rockstor.com/t/syncthing-rock-on/180>`_ area.
+Our `Syncthing Rock-on forum <https://forum.rockstor.com/t/syncthing-rock-on/180>`_ area.
 
 .. _syncthing_whatis:
 
@@ -27,13 +27,13 @@ features an easy to use WebGUI making it a nice fit with Rockstor.
 Syncthing Documentation
 -----------------------
 
-Syncthing's `own documentation <http://docs.syncthing.net/>`_ is the best place
+Syncthing's `own documentation <https://docs.syncthing.net/>`_ is the best place
 to start with understanding its nature and capabilities, they also have a very
 accessible `getting started
-<http://docs.syncthing.net/intro/getting-started.html#getting-started>`_ guide.
+<https://docs.syncthing.net/intro/getting-started.html#getting-started>`_ guide.
 N.B. if your network gateway router does not have UPnP or you don't wish to
 enable it then please see the
-`Firewall Setup <http://docs.syncthing.net/users/firewall.html#firewall-setup>`_
+`Firewall Setup <https://docs.syncthing.net/users/firewall.html#firewall-setup>`_
 section of syncthing's docs.
 
 .. _syncthing_install:
@@ -67,7 +67,7 @@ Next we select the **Storage areas** for Syncthing's **data** and
 * **syncthing-data** - room enough for your data and snapshots.
 
 If you find that these values are insufficient then please discus this on the
-`Rockstor forum <http://forum.rockstor.com/>`_ so that this document might be
+`Rockstor forum <https://forum.rockstor.com/>`_ so that this document might be
 updated and improved.
 
 .. image:: syncthing_shares.png

--- a/docker-based-rock-ons/transmission-bittorrent.rst
+++ b/docker-based-rock-ons/transmission-bittorrent.rst
@@ -7,14 +7,14 @@ Please be aware of the common prerequisites for all Rockstor :ref:`rockons_intro
 specifically the :ref:`rockons_preinstall` and :ref:`rockons_root`
 requirement.
 
-Our `Transmission Rock-on forum <http://forum.rockstor.com/t/transmission-bittorrent-client-rock-on/181>`_ area.
+Our `Transmission Rock-on forum <https://forum.rockstor.com/t/transmission-bittorrent-client-rock-on/181>`_ area.
 
 .. _transmission_whatis:
 
 What is Transmission
 --------------------
 
-`Transmission <http://www.transmissionbt.com/>`_ is a cross platform Open
+`Transmission <https://transmissionbt.com/>`_ is a cross platform Open
 Source BitTorrent client; is is know for its easy of use. It also has a
 :ref:`WebUI <transmission_ui>` making it a good fit with Rockstor.
 
@@ -23,7 +23,7 @@ Source BitTorrent client; is is know for its easy of use. It also has a
 Transmission Documentation
 --------------------------
 
-Transmission's `about <http://www.transmissionbt.com/about/>`_ page has a number
+Transmission's `about <https://transmissionbt.com/about/>`_ page has a number
 of useful links that should serve as a starting point.
 
 
@@ -112,5 +112,5 @@ We now have the **Default Transmission UI** with a Rockstor torrent in progress:
    :align: center
 
 You can now trial your Transmission Rock-on using a
-`Rockstor Torrent <http://rockstor.com/download.html>`_;
+`Rockstor Torrent <https://rockstor.com/download.html>`_;
 :ref:`transmission_doc`

--- a/docker-based-rock-ons/zoneminder.rst
+++ b/docker-based-rock-ons/zoneminder.rst
@@ -209,7 +209,7 @@ Reproduced here for clarity:-
 
    The default timezone for php is set as America/New_York if you would like
    to change it, edit the php.ini in the config folder.
-   Here's a list of available timezone options: http://php.net/manual/en/timezones.php"
+   Here's a list of available timezone options: https://php.net/manual/en/timezones.php"
 
 It is only required that you do the PATH_ZMS change but all the other changes
 are optional but should enhance your experience.
@@ -279,7 +279,8 @@ above 'Tips and Tricks' we have to change the contents of a file by hand.
 
 If the default of **America/New_York** is inappropriate then you will first
 need to lookup the required *PHP* recognized time zone name on the following
-page: http://php.net/manual/en/timezones.php
+page: `https://www.php.net/manual/en/timezones.php <https://www.php
+.net/manual/en/timezones.php>`_
 
 So for the example of **Europe/London** we can apply this change with the
 following 3 commands, assuming you have a ssh client program installed

--- a/faq.rst
+++ b/faq.rst
@@ -106,13 +106,13 @@ How is Rockstor licensed?
 -------------------------
 
 Rockstor is free software licenced under the terms of GNU General Public
-License version 2. See `here <http://www.gnu.org/licenses>`_ for more details.
+License version 2. See `here <https://www.gnu.org/licenses>`_ for more details.
 
 
 What Linux flavor is rockstor based on?
 ---------------------------------------
 
-Rockstor 3.x is based on `CentOS 7 <http://www.centos.org/>`_. We rebrand
+Rockstor 3.x is based on `CentOS 7 <https://www.centos.org/>`_. We rebrand
 CentOS, add Rockstor software in the form of additional rpms and change the
 installer to make it a bit more straightforward and specific.
 
@@ -157,7 +157,7 @@ What is the current list of supported Rock-ons?
 -----------------------------------------------
 
 For the current list see :ref:`rockons_available`. Note that new ones are added
-regularly and can be requested on the `Forum <http://forum.rockstor.com>`_.
+regularly and can be requested on the `Forum <https://forum.rockstor.com>`_.
 
 
 How do I backup to Rockstor using Apple Time Machine?
@@ -176,7 +176,7 @@ Do you have examples on how to build complete NAS solutions for different storag
 Rockstor is hardware agnostic, so you can build a complete Linux, BTRFS-powered
 NAS solution using the Rockstor NAS OS and hardware of your choice. The only
 requirement is that the system be of a 64bit Intel or compatible architecture.
-Don't hesitate to visit our `Forum <http://forum.rockstor.com>`_ to find user
+Don't hesitate to visit our `Forum <https://forum.rockstor.com>`_ to find user
 stories, example builds, or ask for advice from our community!
 
 
@@ -186,14 +186,14 @@ I run a small organization with 10TB and growing data needs. How can Rockstor he
 With Rockstor, you can scale your infrastructure with low incremental cost to
 support your growing data needs. You can have very large storage capacity,
 limited only by system resources like CPU, RAM etc. Feel free to `contact us
-<http://rockstor.com/about-us.html#contact>`_ with your questions.
+<https://rockstor.com/about-us.html#contact>`_ with your questions.
 
 
 Can I run a small home personal cloud using Rockstor?
 -----------------------------------------------------
 
 Yes. Rockstor can be installed on many small computers like ASUS VivoPC or
-Intel NUC. We recommend visiting our `Forum <http://forum.rockstor.com>`_ for
+Intel NUC. We recommend visiting our `Forum <https://forum.rockstor.com>`_ for
 user stories, examples builds, and request advice or recommendation from the
 community.
 
@@ -201,7 +201,7 @@ community.
 Can Rockstor support my specific storage use case?
 --------------------------------------------------
 
-You can `contact us <http://rockstor.com/about-us.html#contact>`_ with your
+You can `contact us <https://rockstor.com/about-us.html#contact>`_ with your
 requirements and we will get in touch with you. We do storage services and
 support and are happy to enable you to use Rockstor for your storage
 requirements.
@@ -239,7 +239,7 @@ providing the best solution based on BTRFS.
 How can I stay in touch with the latest Rockstor news?
 ------------------------------------------------------
 
-We recommend you join our `community forum <http://forum.rockstor.com>`_,
+We recommend you join our `community forum <https://forum.rockstor.com>`_,
 follow the `rockstor-core project <https://github.com/rockstor/rockstor-core>`_
 on github, and follow us on `twitter <https://twitter.com/rockstorinc>`_.
 
@@ -258,4 +258,4 @@ How can I report bugs and request features?
 
 You can create issues or add comments to existing ones on our `github issue
 tracker <https://github.com/rockstor/rockstor-core>`_. The `forum
-<http://forum.rockstor.com>`_ is also a good place to start.
+<https://forum.rockstor.com>`_ is also a good place to start.

--- a/features.rst
+++ b/features.rst
@@ -125,7 +125,7 @@ value over time.
 UPS managed Shutdown
 --------------------
 
-By integrating the well established `NUT <http://www.networkupstools.org/>`_
+By integrating the well established `NUT <https://networkupstools.org/>`_
 software package and providing a Web-UI, :ref:`rockstor_nut_config` aims to
 make UPS setup easy and straight forward. Defaulting to graceful system
 Shutdown in the event of power outage and a UPS battery low state. If

--- a/gnome-disks-usb/gnome_disks_usb.rst
+++ b/gnome-disks-usb/gnome_disks_usb.rst
@@ -4,7 +4,7 @@ Rockstor USB install disk using Gnome Disks
 ===========================================
 
 Many popular linux desktop distributions including
-`Ubuntu <http://www.ubuntu.com/desktop>`_,
+`Ubuntu <https://ubuntu.com/desktop>`_,
 `Fedora <https://getfedora.org/>`_, and many others, include the
 gnome-disks program by default and as such have a built-in graphical way to
 create a Rockstor USB install disk from the downloadable iso file. What follows
@@ -16,7 +16,7 @@ Steps required
 --------------
 
 First download the latest
-`Rockstor iso image <http://rockstor.com/download.html>`_ then **insert your
+`Rockstor iso image <https://rockstor.com/download.html>`_ then **insert your
 USB key**.
 
 * In Nautilus (the file manager) **Right Click** on the Rockstor iso file and navigate to **Open With** then **Disk Image Writer**

--- a/home_nas_guide.rst
+++ b/home_nas_guide.rst
@@ -28,9 +28,9 @@ hardware components for a home NAS build
       
 **A Server**
           
-A server with at least `minimum system requirements <http://rockstor.com/docs/quickstart.html#minimum-system-requirements>`_
+A server with at least `minimum system requirements <https://rockstor.com/docs/quickstart.html#minimum-system-requirements>`_
           
-`HP Proliant Microserver <http://www8.hp.com/us/en/products/proliant-servers/product-detail.html?oid=5379860#!tab=features">`_ (Chosen for its small form factor, 4 easily accessible hard drive slots, and eSata capability to expand storage)
+HP Proliant Microserver (Chosen for its small form factor, 4 easily accessible hard drive slots, and eSata capability to expand storage)
 
 Sample configuration:
 
@@ -43,19 +43,20 @@ Sample configuration:
 **Hard drives**
           
 Hard drives to hold your data. Multiple hard drives are recommended, to create pools for RAID capability.</p> 
-`Western Digital Red <http://www.wd.com/en/products/products.aspx?id=810>`_ series or the `Seagate NAS <http://www.seagate.com/internal-hard-drives/nas-drives/nas-hdd/>`_ series.
+`Western Digital Red <https://shop.westerndigital.com/c/all-products?id=810>`_ series or the `Seagate NAS <https://www.seagate.com/products/nas-drives/ironwolf-hard-drive/>`_ series.
           
 **USB Flash drives**
 
 2 USB flash drives, one for the installation media (at least 1GB), and one that will hold the OS (at least 8GB). If you have a CD drive installed, and blank CDs available, you can use a CD as the installation media.</p>
 
-`SanDisk Cruzer Fit <http://www.sandisk.com/products/usb/drives/cruzer-fit/>`_
+`SanDisk Cruzer Fit <https://shop.westerndigital.com/products/usb-flash-drives/sandisk-cruzer-fit-usb-2-0>`_
       
 **Software**
       
-Download the Rockstor iso at `http://www.rockstor.com/downloads <http://rockstor.com/download.html>`_
+Download the Rockstor iso at `https://www.rockstor.com/downloads <https://rockstor.com/download.html>`_
 
-If you are using a USB drive as the installation media, prepare the USB drive with the Rockstor iso by following `these instructions <https://fedoraproject.org/wiki/How_to_create_and_use_Live_USB>`_
+If you are using a USB drive as the installation media, prepare the USB drive
+with the Rockstor iso by following `these instructions <https://docs.fedoraproject.org/en-US/quick-docs/creating-and-using-a-live-installation-image/index.html#proc_creating-and-using-live-usb>`_
 
 **Installation and Setup**
 

--- a/install.rst
+++ b/install.rst
@@ -34,28 +34,26 @@ that are known to work with Rockstor. Below is a list of these recommendations.
 Please note, however, that the following examples are to be taken as
 illustrations of possible builds at the time of writing and will likely be
 rapidly outpaced by the rapidly evolving hardware market. We always recommend
-visiting our `Forum <http://forum.rockstor.com>`_ for user stories, example
+visiting our `Forum <https://forum.rockstor.com>`_ for user stories, example
 builds, and request advice on hardware choice or recommendations.
 
 Complete Builds for Home and small organizations
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 You can find user stories and example builds on our
-`Forum <http://forum.rockstor.com>`_, but some excerpts are listed below:
+`Forum <https://forum.rockstor.com>`_, but some excerpts are listed below:
 
 1. A build used by Rockstor developers and at least some known
    community members uses `ASRock C2550D4I
    <https://www.asrockrack.com/general/productdetail.asp?Model=C2550D4I>`_
    with `this memory
-   <http://www.kingston.com/us/memory/search/?partid=kvr16le11/8>`_. The
+   <https://www.kingston.com/unitedstates/us/memory/search/discontinuedmodels?partId=kvr16le11%2F8>`_. The
    motherboard provides 12 SATA ports, so `this
-   <http://www.silverstonetek.com/product.php?pid=452>`_ is a recommended tower
+   <https://www.silverstonetek.com/product.php?pid=452>`_ is a recommended tower
    case to hold up to 12 hard drives.
 
-2. Yet another recommendation used by Rockstor team is `HP Microserver
-   <http://www8.hp.com/us/en/products/proliant-servers/product-detail.html?oid=5379860>`_. Note
-   that the link refers to gen8 which may be in use by some community members,
-   but gen7 is the one in use by the Rockstor team.
+2. Yet another recommendation used by some community members is HP Proliant
+   Microserver Gen8.
 
 Upgrading Rockstor
 ------------------

--- a/installer-howto/installer-howto.rst
+++ b/installer-howto/installer-howto.rst
@@ -8,19 +8,28 @@ Rockstor’s “Built on openSUSE” installer - Beta release
 Thanks
 ------
 
-Rockstor’s developers would like to thank the entire OSS community for making any of this possible.
-Specifically with our fledgling move / rebase on openSUSE Leap15.2 our thanks go to the openSUSE/SuSE organisations
-and the larger community for the extreme generosity we all benefit from in a myriad of seen and unseen ways.
+Rockstor’s developers would like to thank the entire OSS community for making
+any of this possible. Specifically with our fledgling move / rebase on openSUSE
+Leap 15.2 our thanks go to the openSUSE/SuSE organisations and the larger
+community for the extreme generosity we all benefit from in a myriad of seen
+and unseen ways.
 
-**Please note: Rockstor is in no way affiliated with openSUSE / SuSE and does not wish, under any circumstances, to misrepresent these organisations.**
-*Any errors you encounter are most likely our fault and we try, on a current volunteer basis, to support our users via our* `friendly forum <https://forum.rockstor.com/>`_.
+**Please note: Rockstor is in no way affiliated with openSUSE / SuSE and does
+not wish, under any circumstances, to misrepresent these organisations.**
+*Any errors you encounter are most likely our fault and we try, on a current
+volunteer basis, to support our users via our* `friendly forum <https://forum.rockstor.com/>`_.
 
-It is hoped that Rockstor’s ongoing small contribution back to the larger community is of value,
-and if this is so for you please consider either subscribing to our Stable Channel updates or taking part in our developer orientated Testing Channel.
-Details of these Rockstor package update services are available in our `Official Docs <https://rockstor.com/docs/>`_ subsection `Update Channels <https://rockstor.com/docs/update-channels/update_channels.html>`_.
-Rockstor’s ongoing development is wholly dependent on community support via either of these channels and by positively participating in our forum, linked above.
-It is hoped that in time we can contribute back more significantly, and possibly financially, as our own community and Stable Channel subscriptions grow.
-Also note that irrespective of Rockstor update channel selection or otherwise, upstream updates are available by normal command line means and via our Web-UI.
+It is hoped that Rockstor’s ongoing small contribution back to the larger
+community is of value, and if this is so for you please consider either
+subscribing to our Stable Channel updates or taking part in our developer
+orientated Testing Channel. Details of these Rockstor package update services
+are available in our subsection on :ref:`update_channels`. Rockstor’s ongoing
+development is wholly dependent on community support via either of these
+channels and by positively participating in our forum, linked above. It is
+hoped that in time we can contribute back more significantly, and possibly
+financially, as our own community and Stable Channel subscriptions grow. Also
+note that irrespective of Rockstor update channel selection or otherwise,
+upstream updates are available by normal command line means and via our Web-UI.
 See :ref:`dash_and_updates` later in this guide for the details.
 
 .. _our_kiwi_ng_installer:
@@ -28,10 +37,14 @@ See :ref:`dash_and_updates` later in this guide for the details.
 Our "Built on openSUSE" Kiwi-ng created installer
 -------------------------------------------------
 
-The existence of this installer, and those of many Linux distributions, is down in a major part to the Kiwi installer creation tool.
-I would specifically like to thank `Marcus Schafer <https://github.com/schaefi>`_ and David `Cassany Viladomat <https://github.com/davidcassany>`_
-of openSUSE/SuSE for their timely and rapid oem, partition, swap, and btrfs related fixes that were required for our initial version of this installer.
-Please contribute to this important multi-distribution upstream project if you have the means and/or talent `KIWI - Next Generation <https://github.com/OSInside/kiwi>`_.
+The existence of this installer, and those of many Linux distributions, is down
+in a major part to the Kiwi installer creation tool. I would specifically like
+to thank `Marcus Schafer <https://github.com/schaefi>`_ and David
+`Cassany Viladomat <https://github.com/davidcassany>`_ of openSUSE/SuSE for
+their timely and rapid oem, partition, swap, and btrfs related fixes that were
+required for our initial version of this installer. Please contribute to this
+important multi-distribution upstream project if you have the means and/or
+talent `KIWI - Next Generation <https://github.com/OSInside/kiwi>`_.
 
 Initial Selection Screen
 ^^^^^^^^^^^^^^^^^^^^^^^^
@@ -44,7 +57,8 @@ The default is "Boot from Hard Disk".
    :align: center
 
 Use cursor keys to highlight, then the "Enter" key to select.
-Only use Failsafe if the 'Install ...' option fails, i.e. the screen goes blank and does not return.
+Only use Failsafe if the 'Install ...' option fails, i.e. the screen goes blank
+and does not return.
 
 Select Installation Disk
 ^^^^^^^^^^^^^^^^^^^^^^^^
@@ -57,11 +71,14 @@ If unsure do not proceed and select <Cancel> via Tab key and then Enter.
    :align: center
 
 Use cursor keys to highlight, then the "Enter" key to select.
-Only devices less than 500 GB are shown. Larger disks are assumed to be data disks.
+Only devices less than 500 GB are shown. Larger disks are assumed to be data
+disks.
 
 Destroying ALL data on ..., continue ?
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Do not proceed if at all unsure. This will wipe the entire contents of the indicated drive.
+
+Do not proceed if at all unsure. This will wipe the entire contents of the
+indicated drive.
 
 .. image:: destroy-all-data.png
    :scale: 80%
@@ -78,7 +95,8 @@ This step may take a while, please be patient.
    :scale: 80%
    :align: center
 
-After 100% there will be more scrolling text that may pause for a few minutes depending on computer and selected drive speed.
+After 100% there will be more scrolling text that may pause for a few minutes
+depending on computer and selected drive speed.
 
 Select Locale
 ^^^^^^^^^^^^^
@@ -100,14 +118,16 @@ Use cursor keys to highlight, then the "Enter" key to select.
 
 GPLv2 & openSUSE based Rockstor License Agreement
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Rockstor is "Built on openSUSE" and so our installer and the consequent installs are considered modified copies of the indicated openSUSE variant.
+Rockstor is "Built on openSUSE" and so our installer and the consequent
+installs are considered modified copies of the indicated openSUSE variant.
 
 .. image:: gplv2_license_agreement.png
    :scale: 80%
    :align: center
 
-Use cursor keys or Page-up / Page-down (space bar) to view the entire agreement.
-There are about 3 pages: Enter key to 'Exit' & 'Agree', or cursor keys to select 'No' in pop up.
+Use cursor keys or Page-up / Page-down (space bar) to view the entire
+agreement. There are about 3 pages: Enter key to 'Exit' & 'Agree', or cursor
+keys to select 'No' in pop up.
 
 Select Time Zone
 ^^^^^^^^^^^^^^^^
@@ -135,8 +155,8 @@ Confirm root User Password
 Wait for the "Rockstor bootstrapping tasks"
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-The Rockstor tasks may take a few minutes to appear, depending on computer and selected drive speed.
-But will normally appear in less than 2 minutes.
+The Rockstor tasks may take a few minutes to appear, depending on computer and
+selected drive speed, but will normally appear in less than 2 minutes.
 
 .. image:: wait_for_rockstor_tasks.png
    :scale: 80%
@@ -147,7 +167,8 @@ Press the Enter key to show the login prompt again.
 Login as the 'root' user
 ^^^^^^^^^^^^^^^^^^^^^^^^
 
-This one-off login is required to find the Web-UI's address for use in your browser.
+This one-off login is required to find the Web-UI's address for use in your
+browser.
 
 .. image:: root_login_myip.png
    :scale: 80%
@@ -160,13 +181,15 @@ Visit Rockstor's Web-UI
 
 Rockstor defaults to a self signed https certificate.
 
-Although more secure than 'http' (no 's') your browser will still present a warning:
+Although more secure than 'http' (no 's') your browser will still present a
+warning:
 
 .. image:: self_signed_certificate_advanced.png
    :scale: 80%
    :align: center
 
-As your Rockstor is on your Local Area Network (LAN) you can add an exception for this address.
+As your Rockstor is on your Local Area Network (LAN) you can add an exception
+for this address.
 Click Advanced:
 
 .. image:: self_signed_certificate_accept.png
@@ -175,11 +198,13 @@ Click Advanced:
 
 Then "Accept the Risk and Continue".
 *Do not do this for any site on the internet.*
-You can use a 'real' domain certificate with Rockstor but this is an advanced topic beyond the scope of this installer guide.
+You can use a 'real' domain certificate with Rockstor but this is an advanced
+topic beyond the scope of this installer guide.
 
 Rockstor Setup and EULA
 ^^^^^^^^^^^^^^^^^^^^^^^
-The following shows example entries for this initial Web-UI setup screen, they are blank by default.
+The following shows example entries for this initial Web-UI setup screen, they
+are blank by default.
 
 .. image:: initial_rockstor_setup_screen.png
    :scale: 80%
@@ -195,8 +220,9 @@ This link opens an additional tab shown below:
 Welcome banner
 ^^^^^^^^^^^^^^
 
-Directly after the initial Rockstor setup the following welcome banner introduces the Rockstor package Update Channels.
-A link to our documentation explaining these channels is included:
+Directly after the initial Rockstor setup the following welcome banner
+introduces the Rockstor package Update Channels. A link to our documentation
+explaining these channels is included:
 
 .. image:: initial_welcome_banner.png
    :scale: 80%
@@ -208,9 +234,10 @@ A link to our documentation explaining these channels is included:
 Dashboard and System updates
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-As the GPLv2 + licensed "rockstor" package stands on the shoulders of numerous OSS giants,
-it is possible to update all upstream, read openSUSE/SuSE, provided/curated packages
-via the flashing icon to the left of the "Uses openSUSE ..." text in the top right of the Web-UI:
+As the GPLv2 + licensed "rockstor" package stands on the shoulders of numerous
+OSS giants, it is possible to update all upstream, read openSUSE/SuSE,
+provided/curated packages via the flashing icon to the left of the "Uses
+openSUSE ..." text in the top right of the Web-UI:
 
 .. image:: dashboard.png
    :scale: 80%
@@ -221,7 +248,8 @@ Your Rockstor installation is now up and running and ready to be configured.
 Update Channel reminder banner
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Until an Update Channel selection has been made, a reminder banner appears whenever the dashboard is visited:
+Until an Update Channel selection has been made, a reminder banner appears
+whenever the dashboard is visited:
 
 .. image:: update_channel_reminder_banner.png
    :scale: 80%
@@ -230,8 +258,9 @@ Until an Update Channel selection has been made, a reminder banner appears whene
 Enjoy your Rockstor DIY NAS 'Built on openSUSE'
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-All upstream (openSUSE) updates, at time of installer creation, are pre-applied.
-The following repositories are included and enabled in the resulting install.
+All upstream (openSUSE) updates, at time of installer creation, are
+pre-applied. The following repositories are included and enabled in the
+resulting install.
 
 
 `OSS <https://en.opensuse.org/Package_repositories#OSS>`_ (open source software only)
@@ -243,4 +272,5 @@ The following repositories are included and enabled in the resulting install.
 `NetTime <https://build.opensuse.org/project/show/network:time>`_ (to address a chrony Network-Manager related bug)
 
 
-**No Rockstor package update repository is configured until an Update Channel is selected.**
+**No Rockstor package update repository is configured until an Update Channel
+is selected.**

--- a/installer-howto/installer-howto.rst
+++ b/installer-howto/installer-howto.rst
@@ -13,11 +13,11 @@ Specifically with our fledgling move / rebase on openSUSE Leap15.2 our thanks go
 and the larger community for the extreme generosity we all benefit from in a myriad of seen and unseen ways.
 
 **Please note: Rockstor is in no way affiliated with openSUSE / SuSE and does not wish, under any circumstances, to misrepresent these organisations.**
-*Any errors you encounter are most likely our fault and we try, on a current volunteer basis, to support our users via our* `friendly forum <https://forum.rockstor.com/.>`_.
+*Any errors you encounter are most likely our fault and we try, on a current volunteer basis, to support our users via our* `friendly forum <https://forum.rockstor.com/>`_.
 
 It is hoped that Rockstor’s ongoing small contribution back to the larger community is of value,
 and if this is so for you please consider either subscribing to our Stable Channel updates or taking part in our developer orientated Testing Channel.
-Details of these Rockstor package update services are available in our `Official Docs <http://rockstor.com/docs/>`_ subsection `Update Channels <http://rockstor.com/docs/update-channels/update_channels.html>`_.
+Details of these Rockstor package update services are available in our `Official Docs <https://rockstor.com/docs/>`_ subsection `Update Channels <https://rockstor.com/docs/update-channels/update_channels.html>`_.
 Rockstor’s ongoing development is wholly dependent on community support via either of these channels and by positively participating in our forum, linked above.
 It is hoped that in time we can contribute back more significantly, and possibly financially, as our own community and Stable Channel subscriptions grow.
 Also note that irrespective of Rockstor update channel selection or otherwise, upstream updates are available by normal command line means and via our Web-UI.

--- a/luks/luks.rst
+++ b/luks/luks.rst
@@ -3,7 +3,7 @@
 LUKS Full Disk Encryption
 =========================
 
-LUKS `(Linux Unified Key Setup) <https://gitlab.com/philipg/cryptsetup/blob/master/README.md>`_
+LUKS `(Linux Unified Key Setup) <https://gitlab.com/cryptsetup/cryptsetup/-/blob/master/README.md>`_
 is a cross distribution, kernel based disk encryption standard. A central
 component of which is that all necessary setup information is stored within
 the format header; giving full decryption portability.
@@ -202,4 +202,4 @@ And finally we see the *Whole drive is mapped to a pool* **Map icon** in our
 **Please be aware that the LUKS UI components within Rockstor hide quite a
 bit of complexity and are currently in the early stages of development. But
 the LUKS system itself is stable.** If you experience any difficulties please
-visit `our forum <http://forum.rockstor.com/>`_ and ask away.
+visit `our forum <https://forum.rockstor.com/>`_ and ask away.

--- a/network.rst
+++ b/network.rst
@@ -122,4 +122,4 @@ Implementation details
 
 NetworkManager is used to configure and manage connections. For more
 information see `implementation details
-<http://forum.rockstor.com/t/network-management-implementation-details/441>`_.
+<https://forum.rockstor.com/t/network-management-implementation-details/441>`_.

--- a/nfs_ops.rst
+++ b/nfs_ops.rst
@@ -36,7 +36,7 @@ See YouTube `Create NFS export of a share <https://www.youtube.com/watch?v=4xRsI
 Various fields of the form are explained as follows.
 
 * **Shares to export**: Choose one or more shares to be exported.
-* **NFS Clients** or **Host String**: This field can be a single host, comma sep  arated host names,hostnames with wildcards or IP networks. This field can be c  omplex. For a detailed explanation, read the `manpage <http://linux.die.net/ma  n/5/exports>`_ of exports.
+* **NFS Clients** or **Host String**: This field can be a single host, comma sep  arated host names,hostnames with wildcards or IP networks. This field can be c  omplex. For a detailed explanation, read the `manpage <https://linux.die.net/ma  n/5/exports>`_ of exports.
 * **Writable**: Choose ro to make the share(s) available read-only or rw for
   read-write.
 * **Sync**: async mode is the default and the norm. For synchronous IO, select

--- a/pools-btrfs.rst
+++ b/pools-btrfs.rst
@@ -89,10 +89,10 @@ level. Instead, selectively enable it on Shares.
 Besides not enabling compression at all, there are two additional choices
 
 * **zlib**: Provides slower but higher compression ratio. You can find out
-  more from `zlib.net <http://www.zlib.net/manual.html>`_.
+  more from `zlib.net <https://www.zlib.net/manual.html>`_.
 * **lzo**: A faster compression algorithm but provides lower ratio compared to
   **zlib**. You can find out more from `oberhumer.com
-  <http://www.oberhumer.com/opensource/lzo/>`_.
+  <https://www.oberhumer.com/opensource/lzo/>`_.
 
 
 Mount Options

--- a/pre-install-howto/pre-install-howto.rst
+++ b/pre-install-howto/pre-install-howto.rst
@@ -6,7 +6,7 @@ Pre-Install Best Practice (PBP)
 This howto sets
 out to establish **Best Practice** prior to a **Rockstor install**. It has grown
 out of a number of suggestions on the `Rockstor forum
-<http://forum.rockstor.com/>`_ where problems have been
+<https://forum.rockstor.com/>`_ where problems have been
 encountered that might otherwise have been avoided. The basic premise is to
 first ensure that the hardware you are to install Rockstor on is fit for
 purpose and tested reasonably with the readily available tools.
@@ -17,7 +17,7 @@ Memory Test (memtest86+)
 ------------------------
 
 Built into the Rockstor installer (inherited from the upstream CentOS installer)
-is the famous `memtest86+ <http://www.memtest.org/>`_ boot option. This program
+is the famous `memtest86+ <https://www.memtest.org/>`_ boot option. This program
 is actually derived from the linux kernel itself, the core of the operating
 system that Rockstor is built on, and is a boot option within the Rockstor
 *Troubleshooting* installer menu. Memtest86+ is licensed under the GPL.
@@ -61,7 +61,7 @@ during this test. Version 5.01 and on have a built in CPU temperature monitor.
 If you find that your version of the Rockstor installer doesn't include the 5
 .01 or newer version of memtest86+ and you would like to monitor your CPU
 temperature then download a `Pre-Compiled Bootable ISO
-<http://www.memtest.org/#downiso>`_ from their official page and write it to a
+<https://www.memtest.org/#downiso>`_ from their official page and write it to a
 USB key in exactly the same way you do for a Rockstor install ISO.
 
 .. _wiping_disks:
@@ -70,7 +70,7 @@ Wiping Disks (DBAN)
 -------------------
 
 A popular tool to securely erase HDDs prior to their deployment or disposal is
-`Darils Boot and Nuke <https://www.dban.org/>`_. This tools essentially writes
+`Darils Boot and Nuke <https://dban.org/>`_. This tools essentially writes
 to every part of a
 disks surface and in the process exercises the drive across it's entire
 working area. This like the :ref:`memory_test` will stress the system; in this
@@ -108,7 +108,7 @@ Check Integrity of Downloaded ISO File
 If the original download is corrupt then all else that follows is likely to have
 problems. ISO is computer slang short for ISO9660 which is the
 `International Organization for Standardization
-<http://www.iso.org/iso/home.html>`_ official definition of the structure of
+<https://www.iso.org/home.html>`_ official definition of the structure of
 data on a CD/DVD. If this structure is wrong or the data contained within it is
 corrupt then problems are bound to follow. To avoid this there is a simple
 command that can be executed once the download of the Rockstor iso file is

--- a/quickstart.rst
+++ b/quickstart.rst
@@ -23,7 +23,7 @@ recommendations.
 * One or more additional drives for data use only (less than 1GB ignored, 5GB+ recommended).
 * Ethernet interface (with internet access for updates).
 * All drives must have unique serial numbers (real drives do); not all VM [*]_ systems default to this.
-* A UPS (recommended) that is supported by `NUT <http://www.networkupstools.org/>`_.
+* A UPS (recommended) that is supported by `NUT <https://networkupstools.org/>`_.
 * USB port and 1GB+ USB key for the installation media; or DVD drive and a blank DVD.
 
 .. [*] For VMware ensure you have :code:`disk.EnableUUID="true"` in your .vmx file
@@ -31,14 +31,14 @@ recommendations.
 Download Rockstor
 -----------------
 
-Rockstor `download options <http://rockstor.com/download.html>`_. Create a
+Rockstor `download options <https://rockstor.com/download.html>`_. Create a
 bootable CD or USB drive from the downloaded iso and proceed to the
 :ref:`installation` section.
 
 .. raw:: html
 
    <div class="alert alert-info">
-   For convenience, you can also purchase a USB install disk from <a href="http://shop.rockstor.com/collections/diy-accessories/products/rockstor-usb-install-disk" target="_blank">our shop</a>.
+   For convenience, you can also purchase a USB install disk from <a href="https://shop.rockstor.com/collections/diy-accessories/products/rockstor-usb-install-disk" target="_blank">our shop</a>.
    Thanks for your support!
    </div>
 
@@ -60,7 +60,7 @@ GUI options
 On a Linux Unity or Gnome Desktop see our :ref:`gnome_disks_howto`.
 
 On a Windows Desktop consider using
-`Rawrite32 <http://www.netbsd.org/~martin/rawrite32/>`_.
+`Rawrite32 <https://www.netbsd.org/~martin/rawrite32/>`_.
 
 **Please note** the following USB image writing programs have been found to
 produce **NON working USB install disks** when used with the Rockstor iso and
@@ -155,7 +155,7 @@ about installation.
 
    <div class="alert alert-info">
    If you need further assistance during or post install, you
-   can post a topic on our <a href="http://forum.rockstor.com">Forum</a> or send an email to support@rockstor.com
+   can post a topic on our <a href="https://forum.rockstor.com">Forum</a> or send an email to support@rockstor.com
    </div>
 
 1. Boot your machine with the Rockstor CD or USB and the splash screen will

--- a/rufus-howto/rufus_howto.rst
+++ b/rufus-howto/rufus_howto.rst
@@ -15,7 +15,7 @@ methods.
 
 N.B. The following method and screen captures were proved and
 provided by @D_Jones a
-`Rockstor forum <http://forum.rockstor.com/>`_ member.
+`Rockstor forum <https://forum.rockstor.com/>`_ member.
 
 .. _rufus_steps:
 
@@ -23,7 +23,7 @@ Steps required
 --------------
 
 First download the latest
-`Rockstor iso image <http://rockstor.com/download.html>`_ and the latest
+`Rockstor iso image <https://rockstor.com/download.html>`_ and the latest
 version of `Rufus <https://rufus.ie/>`_ then insert your USB key and run
 Rufus:-
 

--- a/services.rst
+++ b/services.rst
@@ -101,7 +101,7 @@ The individual fields of the form are described below.
   option can have a notable performance cost in some servers (with high number
   of users, for instance), this option is disabled by default. Note, however,
   that this option must be enabled for Rockstor to be able to list AD users and
-  groups in the web-UI. See `SSSD FAQ <https://sssd.io/docs/users/faq.html#when-should-i-enable-enumeration-in-sssd-or-why-is-enumeration-disabled-by-default>`_ for
+  groups in the web-UI. See `SSSD FAQ <https://docs.pagure.org/sssd.sssd/users/faq.html#when-should-i-enable-enumeration-in-sssd-or-why-is-enumeration-disabled-by-default>`_ for
   further details.
 * **Disable automatic ID mapping**: By default, the AD provider will map UID
   and GID values from the objectSID parameter in Active Directory. Check this
@@ -180,7 +180,7 @@ with appropriate values as shown below.
 NUT-UPS
 -------
 
-A (Currently Beta) `Network UPS Tools <http://www.networkupstools.org/>`_
+A (Currently Beta) `Network UPS Tools <https://networkupstools.org/>`_
 based service to orchestrate gracefull system shutdown in the event of a power
 outage. Please see our: :ref:`ups_setup` section for more details.
 

--- a/sftp/sftp.rst
+++ b/sftp/sftp.rst
@@ -214,7 +214,7 @@ As such, note that Cyberduck, as referenced in the :ref:`sftp_osx` section
 above, is also available for various versions of Windows.
 
 A dedicated SFTP client application that has found favour in `our forum
-<http://forum.rockstor.com/>`_ is `WinSCP <https://winscp.net>`_ which is
+<https://forum.rockstor.com/>`_ is `WinSCP <https://winscp.net>`_ which is
 `GPLv3 Licenced <https://winscp.net/eng/docs/license>`_.
 
 .. _sftp_winscp:

--- a/snapshots-btrfs-snapshots.rst
+++ b/snapshots-btrfs-snapshots.rst
@@ -26,7 +26,7 @@ for this purpose.
 
 Internally, Snapshots are BTRFS Snapshots. To find out more about internal
 implementation, go `here
-<http://forum.rockstor.com/t/internal-implementation-of-pools-shares-snapshots-and-clones/453>`_.
+<https://forum.rockstor.com/t/internal-implementation-of-pools-shares-snapshots-and-clones/453>`_.
 
 Snapshot related operations can be managed from the **Snapshots** screen listed
 under the **Storage** tab of the Web-UI.

--- a/soho.rst
+++ b/soho.rst
@@ -25,7 +25,7 @@ Server requirements and suggestions
 
 The first step in building the Rockstor Fileserver is to procure
 hardware. Since Rockstor is a `Free software
-<http://en.wikipedia.org/wiki/Free_software>`_ product based on Linux, there is
+<https://en.wikipedia.org/wiki/Free_software>`_ product based on Linux, there is
 a lot of flexibility. You can purchase hardware that fits your budget and
 performance requirements. See :ref:`minsysreqs` for general guidance. You can
 easily convert an old PC into a Fileserver with Rockstor as long
@@ -38,11 +38,11 @@ examples:
 **Disclaimer: Rockstor is a software only product. We don't recommend or
 certify any particular hardware. These are mere suggestions based on known deployments in our community**
 
-* `HP Proliant Microserver <http://www8.hp.com/us/en/products/proliant-servers/product-detail.html?oid=5379860#!tab=features">`_ is chosen for its small form factor, 4 easily accessible hard drive slots, and eSata capability to expand storage. This is ideal for a simple setup with a small footprint that meets most file storage needs of a small or home office.
+* HP Proliant Microserver is chosen for its small form factor, 4 easily accessible hard drive slots, and eSata capability to expand storage. This is ideal for a simple setup with a small footprint that meets most file storage needs of a small or home office.
 
-* `Dell Poweredge T300 <http://www.dell.com/us/dfb/p/poweredge-t300/pd>`_ is a powerful server tower with Intel Xeon processor that can have upto 24GB Memory and 4 hard drives. This model is officially discontinued by Dell and newer more powerful options are available in it's place.
+* `Dell Poweredge T300 <https://outlet.us.dell.com/ARBOnlineSales/Online/InventorySearch.aspx?brandId=2804&c=us&cs=28&l=en&s=dfb>`_ is a powerful server tower with Intel Xeon processor that can have upto 24GB Memory and 4 hard drives. This model is officially discontinued by Dell and newer more powerful options are available in it's place.
 
-* `IBM System x3400 <http://www-947.ibm.com/support/entry/portal/docdisplay?lndocid=migr-64905>`_ is a powerful server tower similar to the Dell mentioned above. It can have upto 32GB Memory and 8 hard drives.
+* `IBM System x3400 <https://www.ibm.com/support/pages/node/807406>`_ is a powerful server tower similar to the Dell mentioned above. It can have upto 32GB Memory and 8 hard drives.
 
 .. _hdds:
 
@@ -91,7 +91,7 @@ Here's what you need before proceeding with installation
 7. (Optional) 1 GB USB drive if you choose to install from the USB instead of
    CD/DVD ROM.
 8. The Rockstor ISO file, downloadable from
-   `http://rockstor.com/download. <http://rockstor.com/download.html>`_
+   `https://rockstor.com/download. <https://rockstor.com/download.html>`_
 9. A blank CD-R/RW to burn the ISO file to. This is not necessary if installing
    from a USB flash drive as mentioned in step 7.
 10. A monitor, keyboard and a mouse to drive the install process.
@@ -129,13 +129,13 @@ A USB flash drive of at least 1 GB in size is required. **All data on the USB
 drive will be erased**. So backup your data as needed before proceeding
 further.
 
-On Windows or Fedora operating systems, Liveusb-creator program can be used to
-prepare your USB flash drive with the Rockstor ISO file. If you are using the
-Windows operating system then liveusb-creator can be download from
-`liveusb-creator. <https://fedorahosted.org/releases/l/i/liveusb-creator/liveusb-creator-3.12.0-setup.exe>`_
+On Windows or Fedora operating systems, the Fedora Media Writer program can be
+used to prepare your USB flash drive with the Rockstor ISO file. If you are
+using the Windows operating system then Fedora Media Writer can be downloaded
+from `GetFedora.org <https://getfedora.org/fmw/FedoraMediaWriter-win32-latest.exe>`_
 and install it. On Fedora, run the following command::
 
-    # yum install liveusb-creator
+    # sudo dnf install mediawriter
 
 On Mac or any Linux operating system, use the **dd** program to prepare the USB
 flash drive by running the following command::

--- a/support.rst
+++ b/support.rst
@@ -4,7 +4,7 @@
 Support
 =======
 
-See our website for `Commercial Support <http://rockstor.com/commercial_support.html>`_ options.
+See our website for `Commercial Support <https://rockstor.com/commercial_support.html>`_ options.
 
 Or visit our friendly `Community Forum <https://forum.rockstor.com/>`_ for free support.
 

--- a/update-channels/update_channels.rst
+++ b/update-channels/update_channels.rst
@@ -11,17 +11,17 @@ GNU GPLv2 Licenced
 The code that makes Rockstor possible is developed under the
 `GNU GPLv2 <https://www.gnu.org/licenses/old-licenses/gpl-2.0.html>`_ licence
 and is therefore fully Open Source, there is no contributor agreement and everyone is encouraged to help in what ever way they can.
-It is very much developed in the open with key decisions made by the community and their interaction with Rockstor contributors and maintainers `Our Mission <http://rockstor.com/about-us.html>`_.
-This flow of ideas and open development is held as a founding principal and is instantiated in the `Rockstor forum <http://forum.rockstor.com/>`_ and within the code itself
+It is very much developed in the open with key decisions made by the community and their interaction with Rockstor contributors and maintainers `Our Mission <https://rockstor.com/about-us.html>`_.
+This flow of ideas and open development is held as a founding principal and is instantiated in the `Rockstor forum <https://forum.rockstor.com/>`_ and within the code itself
 `on GitHub <https://github.com/rockstor>`_.
 
-`Rockstor <http://rockstor.com/>`_ the project
+`Rockstor <https://rockstor.com/>`_ the project
 embodies an identifiable software distributor and coordinator of the Open Source product that is the scheduled Rockstor releases.
 It also forms an identifiable entity necessary for the support of the releases (where needed) and infrastructure necessary to maintain the open development
 that is essential in modern non trivial software appliances that have any hope of qualifying as **future-proof**.
 
 After an initial development of 2.5 years the sustainable nature of this endeavour was approached and redressed in
-`a thread on the community forum <http://forum.rockstor.com/t/would-you-pay-a-one-time-charge-for-stable-updates/448/21>`_.
+`a thread on the community forum <https://forum.rockstor.com/t/would-you-pay-a-one-time-charge-for-stable-updates/448/21>`_.
 The consensus was to adopt a two-tiered updates model; testing and stable.
 
 ..  image:: update_channel_options.png

--- a/ups-setup/ups_setup.rst
+++ b/ups-setup/ups_setup.rst
@@ -7,12 +7,12 @@ UPS / NUT Setup
 for production use.**
 
 *Bug reports or suggestions are always welcome on*
-`our friendly forum <http://forum.rockstor.com/>`_.
+`our friendly forum <https://forum.rockstor.com/>`_.
 
 Overview
 --------
 
-Rockstor uses the `NUT software collection <http://www.networkupstools.org/>`_
+Rockstor uses the `NUT software collection <https://networkupstools.org/>`_
 to orchestrate a graceful system shutdown in the presence of mains power
 failure. It does this by continuously monitoring a UPS device to maintain a
 knowledge of safe power conditions. In the event of those conditions changing
@@ -49,7 +49,7 @@ time in use is sufficient to meet this *safe shutdown* criteria.
 What is NUT
 -----------
 
-NUT stand for `Network UPS Tools <http://www.networkupstools.org/>`_ and is a
+NUT stand for `Network UPS Tools <https://networkupstools.org/>`_ and is a
 collection of GPLv2 licenced packages that enables communication between UPS
 systems and their protected equipment. It also has the facility to share this
 information on the local lan so that equipment that is powered by the UPS but
@@ -97,7 +97,7 @@ the mains / ups data with any other machine. This mode requires the following
 fields:
 
 * **NUT Mode** - A drop down and in this case **standalone** is required
-* **NUT Driver** - Please see NUT's `Hardware Compatibility List <http://www.networkupstools.org/stable-hcl.html>`_ to select the correct driver for your particular UPS make and model.
+* **NUT Driver** - Please see NUT's `Hardware Compatibility List <https://networkupstools.org/stable-hcl.html>`_ to select the correct driver for your particular UPS make and model.
 * **UPS Port** - the port name for how the UPS data cable is connected to the Rockstor machine eg - **/dev/ttyS0** for the first serial port - **/dev/ttyUSB0** for the first USB to serial port adapter - **auto** for many directly usb connected UPSs.
 * **NUT User** - N.B. this is **NOT** a system user but reserved solely for internal NUT use; if you have no specific requirement here then just enter the suggestion of *monuser*.
 * **NUT User Password** - A password for the above nut specific user; if you are going with the default 'NUT User' of *monuser* in the last field then simply make up and enter a fresh and unique password here.
@@ -108,7 +108,7 @@ fields:
 
 Note in the above mouse over hint there is a web link to assist in driver
 selection; repeated here for convenience:-
-`Hardware Compatibility List <http://www.networkupstools.org/stable-hcl.html>`_
+`Hardware Compatibility List <https://networkupstools.org/stable-hcl.html>`_
 
 .. _nut_netserver:
 

--- a/windows-shadow-copy.rst
+++ b/windows-shadow-copy.rst
@@ -15,7 +15,7 @@ example.
 In the Windows world, this feature is called `Shadow Copy
 <https://en.wikipedia.org/wiki/Shadow_Copy>`_. The server side of this feature
 is what Rockstor supports by using Samba's `vfs_shadow_copy2
-<https://www.samba.org/samba/docs/man/manpages/vfs_shadow_copy2.8.html>`_ which
+<https://www.samba.org/samba/docs/current/man-html/vfs_shadow_copy2.8.html>`_ which
 understands BTRFS Snapshots and exposes them to Windows clients as shadow
 copies.
 


### PR DESCRIPTION
Fixes #278 
@phillxnet, ready for review.
This pull request's proposal

This pull request simply fixes the few links that were identified as broken.
Note that it seems the linkcheck result is not 100% consistent as, for instance, the error with the link to bitcoin.com reported in #278 could not be reproduced. It usually seems to be worth retrying a few times to confirm the broken nature of a link.

In an attempt to ease `make linkcheck` task, improve its consistency, and improve our overall state of links, the following has also been done:
- Update links to https when possible: also eliminates unnecessary redirects.
- Link to final target for most links permanently redirected: eliminates unnecessary redirects.
- Remove deprecated links to HP Proliant Microserver Gen7/8: these links were problematic and were redirected to a generic page anyway.


### Checklist
- [x] With the proposed changes no Sphinx errors or warnings are generated.
- [x] I have added my name to the AUTHORS file, if required (descending alphabetical order).