### PR TITLE
Replace external links with sphinx's intra project reference

### DIFF
--- a/home_nas_guide.rst
+++ b/home_nas_guide.rst
@@ -28,7 +28,7 @@ hardware components for a home NAS build
       
 **A Server**
           
-A server with at least `minimum system requirements <https://rockstor.com/docs/quickstart.html#minimum-system-requirements>`_
+A server with at least the :ref:`minsysreqs`.
           
 HP Proliant Microserver (Chosen for its small form factor, 4 easily accessible hard drive slots, and eSata capability to expand storage)
 


### PR DESCRIPTION
Fixes #283 

### This pull request's proposal
As detailed in #283, we had a remaining external link pointing to a different section of our documentation. This pull request simply switches this external reference to Sphinx's intra-documentation reference (`:ref:`).

### Checklist
- [ ] With the proposed changes no Sphinx errors or warnings are generated.
- [ ] I have added my name to the AUTHORS file, if required (descending alphabetical order).