### PR TITLE
Remove external call to EdgeFonts and use standard web-safe fonts (#285)

### DIFF
--- a/themes/rockstor/layout.html
+++ b/themes/rockstor/layout.html
@@ -6,7 +6,6 @@
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>Rockstor | Linux and BTRFS powered Opensource NAS solution</title>
-<script src="http://use.edgefonts.net/source-sans-pro.js"></script>
 <script src="{{ pathto('_static/' + 'js/libs/bootstrap.js', 1) }}"></script>
 <script type="text/javascript">
     <!-- Adds target=_blank to external links -->

--- a/themes/rockstor/static/css/style.css
+++ b/themes/rockstor/static/css/style.css
@@ -40,13 +40,13 @@ h1, h2, h3, h4, h5, h6 {
   /* Fonts */
   /*body { font: 14px/1.5em "Helvetica Neue",Helvetica,Arial,sans-serif; }*/
   body { 
-    font-family: source-sans-pro, sans-serif;
+    font-family: Arial, Verdana, sans-serif;
     font-size: 16px;
     line-height: 1.5em; 
   }
   
   h1, h2, h3, h4, h5, h6, .h1, .h2, .h3, .h4 {
-    font-family: source-sans-pro, sans-serif;
+    font-family: Arial, Verdana, sans-serif;
     font-weight: normal;
     color: #333;
   }
@@ -95,7 +95,7 @@ h1, h2, h3, h4, h5, h6 {
     margin-bottom: 0px;
     font-size: 12px/1.5em;
     /*font-family: "Helvetica Neue",Helvetica,Arial,sans-serif;*/
-    font-family: source-sans-pro, sans-serif;
+    font-family: Arial, Verdana, sans-serif;
   }
   
   .navbar-inner {
@@ -899,7 +899,7 @@ h1, h2, h3, h4, h5, h6 {
   
   #main-story-download { 
     font-size: 24px; 
-    font-family: source-sans-pro, sans-serif;
+    font-family: Arial, Verdana, sans-serif;
     padding: 12px 18px; 
   }
   


### PR DESCRIPTION
Fixes #285 
@phillxnet, ready for review.

### This pull request's proposal
We currently run a call to an external, http, online service (EdgeFonts) to use the `source-sans-pro` font that is blocked by browsers due to mixed http/https. As discussed in #285, it is proposed to deprecate this external call and instead rely on standard web-safe fonts (as currently happening anyway due to the external call to EdgeFonts being blocked).

This pull-request (PR) thus removes the call to EdgeFonts from our `layout.html`, and instead sets a stack of web-safe sans-serif fonts in our `style.css`:
```css
    font-family: Arial, Verdana, sans-serif;
```
These fonts are standard and believed to be safe in all modern browsers (https://www.w3schools.com/cssref/css_websafe_fonts.asp).

### Checklist
- [x] With the proposed changes no Sphinx errors or warnings are generated.
- [x] I have added my name to the AUTHORS file, if required (descending alphabetical order).