### PR TITLE
Wrap body block in div with "main" role (#289)

### DIFF
--- a/themes/rockstor/layout.html
+++ b/themes/rockstor/layout.html
@@ -104,19 +104,22 @@
                 </div>
             </div>
             <div class="col-lg-8 col-xs-12">
-                {% block body %}{% endblock %}
-		<div class="pull-left">
-		  {% if prev %}
-		  <a href="{{ prev.link|e }}">{{ prev.title }}</a>&nbsp;&nbsp;
-		  <span class="fa fa-arrow-circle-left"></span>
-		  {% endif %}
-		</div>
-		<div class="pull-right">
-		  {% if next %}
-		  <span class="fa fa-arrow-circle-right"></span>&nbsp;&nbsp;
-		  <a href="{{ next.link|e }}">{{ next.title }}</a>
-		  {% endif %}
-		</div>
+                <!-- role="main" required to display search result contents -->
+                <div role="main">
+                    {% block body %}{% endblock %}
+                </div>
+                <div class="pull-left">
+                    {% if prev %}
+                    <a href="{{ prev.link|e }}">{{ prev.title }}</a>&nbsp;&nbsp;
+                    <span class="fa fa-arrow-circle-left"></span>
+                    {% endif %}
+                </div>
+                <div class="pull-right">
+                    {% if next %}
+                    <span class="fa fa-arrow-circle-right"></span>&nbsp;&nbsp;
+                    <a href="{{ next.link|e }}">{{ next.title }}</a>
+                    {% endif %}
+                </div>
             </div>
         </div>
 


### PR DESCRIPTION
Fixes #289 
@phillxnet, ready for review.

### This pull request's proposal
As illustrated in #289, search results, while correctly found, search results do not displayed the matched content. This is caused by the related related looking for a div with the `"main"` role. As described in #289, this can be fixed by wrapping either the `body` or `document` block into such a div; this is thus what this pull-request proposes.

### Checklist
- [x] With the proposed changes no Sphinx errors or warnings are generated.
- [x] I have added my name to the AUTHORS file, if required (descending alphabetical order).