### PR TITLE
Define CSS styles for admonitions

### DIFF
--- a/data_loss.rst
+++ b/data_loss.rst
@@ -24,12 +24,9 @@ We have servers with different types of pools and usecases here at Rockstor
 which are constantly put to test. We also rely on Rockstor and BTRFS
 communities to report and fix issues and help improve Rockstor.
 
-.. raw:: html
-
-   <div class="alert">
-   We strongly recommend that you have a backup of all critical Shares
-   on Rockstor to another system.
-   </div>
+.. warning::
+   We strongly recommend that you have a backup of all critical Shares on
+   Rockstor to another system.
 
 Backup Recommendations
 ----------------------
@@ -223,23 +220,23 @@ If your raid5/6 pool has 3/4 or more drives and a single drive fails, you can
 follow these steps to replace it with a new drive and balance(rebuild) the
 pool.
 
-.. raw:: html
+.. warning::
+   **Important!**
 
-   <div class="alert">
-   <strong>Important!</strong> These steps only apply to raid5 pools with 3+
-   drives or raid6 pools with 4+ drives
-   <br />
+   These steps only apply to raid5 pools with 3+ drives or raid6
+   pools with 4+ drives.
+
    These steps are tested, but we cannot guarantee the accuracy given the
-   current state of raid5/6 in BTRFS. There are known but unresolved bugs
-   which may make balances for a small number of users take an order of magnitude
+   current state of raid5/6 in BTRFS. There are known but unresolved bugs that
+   may make balances for a small number of users take an order of magnitude
    longer than expected.
-   <br />
-   The BTRFS replace command is highly experimental, may take an extrodinarily long
-   amount of time to complete in the case of a missing drive, suffers from a cirtical memory leak
-   on kernel versions <4.7 and may fail in a way that destroys data on repeated usage. The
-   recommended method for replacing a device is adding a new device then deleting the missing device
-   as outlined in this section.
-   </div>
+
+   The BTRFS :code:`replace` command is highly experimental, may take an
+   extraordinarily long amount of time to complete in the case of a missing
+   drive, suffer from a critical memory leak on kernel versions <4.7 and may
+   fail in a way that destroys data on repeated usage. The recommended method
+   for replacing a device is adding a new device then deleting the missing
+   device as outlined in this section.
 
 0. Suppose there is a raid5 pool called "mypool" with drives: sda, sdb, sdc,
    sdd. sdd is failed.
@@ -272,6 +269,6 @@ pool.
 
       # btrfs device delete missing /mnt2/mypool
 
-If multiple drives fail simultaneously, then the scenrio becomes catastrophic
+If multiple drives fail simultaneously, then the scenario becomes catastrophic
 similar to a raid0 pool. In such case, follow the recovery strategy described
-in :ref:`datalossraid0`
+in :ref:`datalossraid0`.

--- a/installation/quickstart.rst
+++ b/installation/quickstart.rst
@@ -203,17 +203,14 @@ You can also read (for a Rockstor 3 example)
 :ref:`vmmrockstorinstall` section of our :ref:`kvmsetup` for more information
 about our older Rockstor 3 installation.
 
-.. raw:: html
+.. warning::
+   **Important!** Installing Rockstor deletes existing data on the system
+   drive(s) selected as installation destination.
 
-   <div class="alert alert-warning">
-   <strong>Important!</strong> Installing Rockstor deletes existing data on the
-   system drive(s) selected as installation destination.
-   </div>
-
-   <div class="alert alert-info">
-   If you need further assistance during or post install, you
-   can post a topic on our <a href="https://forum.rockstor.com">Forum</a> or send an email to support@rockstor.com
-   </div>
+.. note::
+   If you need further assistance during or post install, you can post a topic
+   on our `Forum <https://forum.rockstor.com>`_ or send an email to
+   support@rockstor.com
 
 1. Boot your machine with the Rockstor CD or USB and the splash screen will
    appear. Press enter and the graphical installer will start momentarily and
@@ -242,12 +239,9 @@ about our older Rockstor 3 installation.
       scheme. However, note that Rockstor only supports **BTRFS** for its root
       filesystem.
 
-    .. raw:: html
-
-        <div class="alert alert-warning">
-        <strong>Important!</strong> Installing Rockstor deletes existing data on the system
-        drive(s) selected as installation destination.
-        </div>
+   .. warning::
+      **Important!** Installing Rockstor deletes existing data on the system
+      drive(s) selected as installation destination.
 
    d. Once the installation configuration is complete and there are no amber
       icons, click on **Begin Installation** button to start the package

--- a/interface/overview.rst
+++ b/interface/overview.rst
@@ -91,7 +91,7 @@ take advantage of the User and/or Group management screens. Navigate to System
 --> Users (or Groups if necessary).
 
 .. image:: /images/interface/docker-based-rock-ons/users_page.png
-   :scale: 30%
+   :width: 100%
    :align: center
 
 The two highlighted columns show the UID and GID. In the example above, the
@@ -370,13 +370,10 @@ description, port number on host, and port number mapped on the corresponding
 container. Finally, a checkbox allows each port to be published (if checked) or
 unpublished (if unchecked).
 
-.. raw:: html
-
-   <div class="alert alert-warning">
-   <strong>Important!</strong> Unpublishing a port defined for the rock-on's webUI will make it
-   inaccessible from Rockstor's rock-ons page. For convenience, such ports are accompanied by a warning
-   icon next to the checkbox.
-   </div>
+.. warning::
+   **Important!** Unpublishing a port defined for the Rock-on's web-UI will
+   make it inaccessible from Rockstor's Rock-ons page. For convenience, such
+   ports are accompanied by a warning icon next to the checkbox.
 
 Click *Next* and verify the new publication state for each port before
 finishing the procedure by clicking *Next* and *Submit*. Internally, Rockstor
@@ -406,14 +403,12 @@ connected to the given container.
 To disconnect a container from a rocknet, simply delete the rocknet's name or
 click the "x" next to it.
 
-.. raw:: html
-
-   <div class="alert alert-warning">
-   <strong>Important!</strong> Rocknets newly-defined directly from this page will be created using docker's
-   default parameters. If different settings are desired, please create the rocknet first from the <em>System</em> >
-   <em>Network</em> menu, and then connect the container to it. Alternatively, it is also possible to edit an
-   existing rocknet's settings from the <em>System</em> > <em>Network</em> menu.
-   </div>
+.. warning::
+   **Important!** Rocknets newly-defined directly from this page will be
+   created using Docker's default parameters. If different settings are
+   desired, please create the rocknet first from the *System* > *Network* menu,
+   and then connect the container to it. Alternatively, it is also possible to
+   edit an existing rocknet's settings from the *System* > *Network* menu.
 
 .. image:: /images/interface/docker-based-rock-ons/rocknets_join.png
    :width: 100%

--- a/interface/storage/file_sharing/apple_filing_protocol.rst
+++ b/interface/storage/file_sharing/apple_filing_protocol.rst
@@ -1,8 +1,9 @@
-.. raw:: html
-
-   <div class="alert alert-warning">
-   <strong>Note:</strong> Following the loss of support for AFP in newer macOS versions, the AFP service is no longer supported as of Rockstor-3.9.2-56. We thus recommend users to use the <a href="https://rockstor.com/docs/samba_ops.html#samba" target="_blank">Samba service</a> instead (see <a href="https://forum.rockstor.com/t/3-9-2-stable-channel-changelog/5741/22" target="_blank">this forum post</a> for details).
-   </div>
+.. warning::
+   **Note:** Following the loss of support for AFP in newer macOS versions, the
+   AFP service is no longer supported as of Rockstor-3.9.2-56. We thus
+   recommend users to use the :ref:`Samba service <samba>` instead (see
+   `this forum post <https://forum.rockstor.com/t/3-9-2-stable-channel-changelog/5741/22>`_
+   for details).
 
 ..  _afp:
 

--- a/interface/storage/shares-btrfs-subvolumes.rst
+++ b/interface/storage/shares-btrfs-subvolumes.rst
@@ -44,14 +44,11 @@ set. To find out more see the btrfs wiki entry
 Share size enforcement temporarily disabled
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-.. raw:: html
-
-   <div class="alert alert-warning">
+.. warning::
    Currently, as of 3.8-7 version, Share size enforcement has been disabled. So
-   the Size input during Share creation has no real effect. Any Share can grow up
-   to the Pool's capacity. Consequently, resizing a Share also has no effect. We
-   will re enable the enforcement when support in BTRFS improves.
-   </div>
+   the Size input during Share creation has no real effect. Any Share can grow
+   up to the Pool's capacity. Consequently, resizing a Share also has no
+   effect. We will re enable the enforcement when support in BTRFS improves.
 
 
 Deleting a Share

--- a/interface/system/config_backup.rst
+++ b/interface/system/config_backup.rst
@@ -14,14 +14,11 @@ extensive configuration changes as it provides the possibility to revert to a
 known good configuration. Once a configuration backup has been generated and
 downloaded it can also be used in system migration scenarios.
 
-.. raw:: html
-
-   <div class="alert alert-warning">
+.. warning::
    Upon restore, the configuration of most features included in the backup
    will be restored regardless of their current state. As a result, their current
-   configuration will be overwritten (to the exception of <em>Users</em> and
-   <em>Groups</em>, see <a href="#special-notes-on-configuration-restore">below</a>).
-   </div>
+   configuration will be overwritten (to the exception of *Users* and
+   *Groups*, see :ref:`below <config_notes>`).
 
 The following state information is saved as part of a backup
 

--- a/themes/rockstor/static/css/style.css
+++ b/themes/rockstor/static/css/style.css
@@ -926,4 +926,31 @@ h1, h2, h3, h4, h5, h6 {
   li { line-height: 24px; }
   
   #top-search { padding-top: 12px; }
-  
+
+/*Style Admonitions*/
+.admonition {
+  padding: 15px;
+  margin-bottom: 20px;
+  border: 1px solid transparent;
+  border-radius: 4px;
+}
+
+.admonition.note {
+  color: #31708f;
+  background-color: #d9edf7;
+  border-color: #bce8f1;
+}
+
+.admonition.warning {
+  color: #8a6d3b;
+  background-color: #fcf8e3;
+  border-color: #faebcc;
+}
+
+.admonition-title {
+  display: none;
+}
+
+.admonition p {
+  margin: 0;
+}


### PR DESCRIPTION
Fixes #288 
@phillxnet, ready for review.

### This pull request's proposal
As described in #288, we currently do not have any style defined for our admonitions and we thus use `.. raw:: html` blocks that in turn use bootstrap.js styles (`alert alert-info` for what could be considered "notes", and `alert alert-warning` for what could be considered "warnings"). While this approach works, it causes issues described in #288.

This pull request (PR) thus proposes to define proper CSS styles for the `.. note::` and `.. warning::` admonitions built in Sphinx and switch the currently used `.. raw:: html` blocks to these admonitions. @phillxnet, you will notice that I kept two commits instead of a singled, squashed one, as I see two distinct changes here:
1. Defining the CSS styles
2. Switching from `.. raw:: html` to the built-in `.. note::` and `.. warning::` directives

For the CSS styles themselves, I simply copied those that were defined in our currently used `alert`, `alert-info`, and `alert-warning` classes from bootstrap.js, and incorporated them in our rockstor sphinx theme. We can always improve them further (now that we have simple, full control, or their styling with our CSS) down the line, but that I thought that would be better suited for a later PR.

### Checklist
- [x] With the proposed changes no Sphinx errors or warnings are generated.
- [x] I have added my name to the AUTHORS file, if required (descending alphabetical order).