### PR TITLE
Reduce padding-left for toc entries and emphasize current entry (#294).

### DIFF
--- a/themes/rockstor/layout.html
+++ b/themes/rockstor/layout.html
@@ -93,7 +93,7 @@
                     <a href="/docs"><h3>Table of contents</h3></a>
                     {%- set toctree = toctree(
                         collapse=True,
-                        maxdepth = 3
+                        maxdepth = 4
                     ) %}
                     {%- if toctree %}
                         {{ toctree }}

--- a/themes/rockstor/static/css/style.css
+++ b/themes/rockstor/static/css/style.css
@@ -923,6 +923,15 @@ h1, h2, h3, h4, h5, h6 {
     padding: 4px 20px 20px 20px !important;
       border-radius: 3px;
   }
+
+  .sphinxsidebarwrapper ul {
+    padding-left: 1.2em;
+  }
+
+  .sphinxsidebarwrapper a.current {
+    font-weight: bold;
+  }
+
   li { line-height: 24px; }
   
   #top-search { padding-top: 12px; }


### PR DESCRIPTION
Fixes #294
@phillxnet, ready for review.

### This pull request's proposal
As detailed in #294, our current table of contents (toc) includes a 20px padding-left for each of its level, which rapidly leads to the toc being difficult to read at levels higher than 3, which explains why I limited the max depth to 3 in #290. This pull-request (PR) proposes to address this issue by doing the following:
- reduce the padding-left
- increasing the toc max depth to 4
- Emphasize the currently selected entry using a bold font-weight

The resulting toc is thus using less horizontal space, allowing for more text to be displayed on each level, and the max depth to be increased to 4. 

Before:
![image](https://user-images.githubusercontent.com/30297881/131254693-d7eb4518-0a3d-4390-8131-3f8462e47a39.png)

After
![image](https://user-images.githubusercontent.com/30297881/131263878-3bd55aec-43d3-4226-be8c-937f91805a79.png)

### Checklist
- [x] With the proposed changes no Sphinx errors or warnings are generated.
- [x] I have added my name to the AUTHORS file, if required (descending alphabetical order).