### PR TITLE
Remove broken link to sickbeard.com website (#306)

### DIFF
--- a/interface/overview.rst
+++ b/interface/overview.rst
@@ -183,7 +183,6 @@ instructions they are like all Rock-on installs, fairly self explanatory.
 * `Rocket.Chat <https://rocket.chat/>`_: Open Source Chat Platform
 * `SaBnzbd <https://sabnzbd.org/>`_: The best usenet downloader
 * `Seafile <https://www.seafile.com/>`_: Secure file sharing and hosting
-* `Sickbeard <https://sickbeard.com/>`_: Internet PVR for your TV shows, by Linuxserver.io
 * `SmokePing <https://oss.oetiker.ch/smokeping/>`_: Network latency history monitor
 * `Sonarr <https://sonarr.tv/>`_: (formerly NZBdrone) A PVR for usenet and bittorrent users
 * `Subsonic <http://www.subsonic.org>`_: Music server


### PR DESCRIPTION
Fixes #306
@phillxnet, ready for review.

### This pull request's proposal
This pull request simply removes a dead link to sickbeard's website as this Rock-on has now been deprecated anyway.
Note that the broken link to Jenkin's wiki (as reported by `make linkcheck`) is fixed in #307 already--sorry for the inconsistency in fixing it there and not here.

### Checklist
- [x] With the proposed changes no Sphinx errors or warnings are generated.
- [x] I have added my name to the AUTHORS file, if required (descending alphabetical order).