### PR TITLE
Define align-center class for img blocks (#311)

### DIFF
--- a/themes/rockstor/static/css/style.css
+++ b/themes/rockstor/static/css/style.css
@@ -963,3 +963,10 @@ h1, h2, h3, h4, h5, h6 {
 .admonition p {
   margin: 0;
 }
+
+/* Images */
+img.align-center {
+  display: block;
+  margin-left: auto;
+  margin-right: auto;
+}


### PR DESCRIPTION
Fixes #311 
@phillxnet, ready for review.

### This pull request's proposal
As detailed in #311, we currently are lacking a definition for the `align: center` option in our `.. image::` directive blocks. This pull request (PR) simply adds that definition.
This definition was taken from Sphinx's basic theme stylesheet:
https://github.com/sphinx-doc/sphinx/blob/9e1b4a8f1678e26670d34765e74edf3a3be3c62c/sphinx/themes/basic/static/basic.css_t#L292-L296

### Checklist
- [x] With the proposed changes no Sphinx errors or warnings are generated.
- [x] I have added my name to the AUTHORS file, if required (descending alphabetical order).