### PR TITLE
Update "Developers" section re recent build changes #319

### DIFF
--- a/contribute/contribute.rst
+++ b/contribute/contribute.rst
@@ -71,8 +71,11 @@ In the following sections we assume:
 4. **buildvm**: is your target build machine's hostname; the name chosen during the rockstor install.
 
 TIP: you can add your buildvm's IP address to /etc/hosts on your laptop (linux assumed).
-An example IP entry would be (checked via :code:`grep "buildvm" /etc/hosts`)::
+E.g.
 
+.. code-block:: console
+
+    you@laptop:~> grep "buildvm" /etc/hosts
     192.168.2.170   buildvm
 
 Then a :code:`ping -c2  buildvm` on your laptop should complete without error.
@@ -95,21 +98,29 @@ They should also work with little or no modification in an OSX console.
 Clone, in turn, your GitHub profiles fork of rockstor-core onto your local machine.
 You can do this in any directory; but the following assume the ~/dev directory.
 
+.. code-block:: console
+
         you@laptop:~> mkdir ~/dev; cd ~/dev
         you@laptop:~/dev> git clone https://github.com/your_github_username/rockstor-core.git
 
 The above creates a local rockstor-core git repo in a new directory by
-the same name: "rockstor-core". Change into this new directory/repo clone via::
+the same name: "rockstor-core". Change into this new directory/repo clone via:
+
+.. code-block:: console
 
         you@laptop:~/dev> cd rockstor-core
 
 Configure this new git repo with your name and email address. This is required
-to accurately record collaboration::
+to accurately record collaboration:
+
+.. code-block:: console
 
         you@laptop:~/dev/rockstor-core> git config user.name "Firstname Lastname"
         you@laptop:~/dev/rockstor-core> git config user.email your_email_address
 
-Add a remote called **upstream** to periodically rebase your local repository with upstream changes by other contributors::
+Add a remote called **upstream** to periodically rebase your local repository with upstream changes by other contributors:
+
+.. code-block:: console
 
         you@laptop:~/dev/rockstor-core> git remote add upstream https://github.com/rockstor/rockstor-core.git
 
@@ -120,12 +131,16 @@ Making changes
 
 Assuming you have identified or created an issue to work on (eg: #1234) from
 `GitHub issue tracker <https://github.com/rockstor/rockstor-core/issues>`_.
-First ensure your local code fork is up-to-date by rebasing on upstream::
+First ensure your local code fork is up-to-date by rebasing on upstream:
+
+.. code-block:: console
 
         you@laptop:~/dev/rockstor-core> git checkout master
         you@laptop:~/dev/rockstor-core> git pull --rebase upstream master
 
-Then checkout a new/issue-specific branch, e.g.::
+Then checkout a new/issue-specific branch, e.g.:
+
+.. code-block:: console
 
         you@laptop:~/dev/rockstor-core> git checkout -b 1234_issue_title
 
@@ -140,7 +155,9 @@ We request that you divide a commit message into two parts.
 Start the message with a single line summary, about 70 characters in length ending in #issue-number.
 Add a blank line after that.
 Further details can then follow in paragraphs less than 80 characters wide.
-Below is a fictional example::
+Below is a fictional example:
+
+.. code-block:: console
 
         foobar functionality for rockstor #1234
 
@@ -202,7 +219,9 @@ The prior existing rpm install must be removed as it will otherwise interfere.
 The following does this, updates the os, and installs the dev dependencies.
 Around 30 packages will already be installed and a similar number will be added:
 if you are using the suggested rockstor-installer derived os instance.
-This change will be around 60 MB download and 250 MB installed. ::
+This change will be around 60 MB download and 250 MB installed.
+
+.. code-block:: console
 
     zypper --non-interactive remove rockstor
     rm -rf /opt/rockstor  # remove dangling rockstor rpm related files.
@@ -221,11 +240,15 @@ Build VM initial setup
 ----------------------
 
 Transfer the code from your laptop to the build VM.
-A password will likely be requested and this is for the buildvm machine's root user.::
+A password will likely be requested and this is for the buildvm machine's root user.
+
+.. code-block:: console
 
         you@laptop:~> rsync -avz --exclude=.git ~/dev/rockstor-core/ root@buildvm:/opt/rockstor-dev/
 
-And via your ssh session to, or console on, **the target buildvm machine** (as root)::
+And via your ssh session to, or console on, **the target buildvm machine** (as root):
+
+.. code-block:: console
 
         buildvm:~ # zypper --non-interactive install python2-pip
         buildvm:~ # pip2 install zc.buildout
@@ -239,7 +262,8 @@ We now have all the tools and code in place on the buildvm machine ready to:
 
 1. Code configure/re-configure
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-::
+
+.. code-block:: console
 
         buildvm:~ # cd /opt/rockstor-dev/
         buildvm:/opt/rockstor-dev # buildout bootstrap
@@ -252,13 +276,17 @@ This step can take a few minutes, depending on cpu and internet speed.
 An internet connection is required as the process downloads all required Python eggs/wheels etc.
 We are running the bin/buildout script generated/updated in :ref:`code_config` step above.
 This stage takes considerably longer if you have also just configured/reconfigured the code.
-::
+
+.. code-block:: console
+
 
          buildvm:/opt/rockstor-dev # bin/buildout -N -c buildout.cfg
 
 The build process, towards the end, enables and starts the following rockstor systemd services.
 **All are installed in /etc/systemd/system/**
-Note that all paths indicated are within the rockstor source tree.::
+Note that all paths indicated are within the rockstor source tree.
+
+.. code-block:: console
 
     rockstor-pre.service  # starts bin/initrock after postgresql.service
     rockstor  # starts bin/supervisord -c etc/supervisord.conf after rockstor-pre.service
@@ -266,6 +294,8 @@ Note that all paths indicated are within the rockstor source tree.::
 
 If a custom HDD power (APM) and/or spin-down setting is enabled, the following service is added.
 But only if the drive is confirmed as rotational.
+
+.. code-block:: console
 
     rockstor-hdparm.service  # Configures drives APM & spindown settings via hdparm
 
@@ -278,7 +308,7 @@ The Rockstor Web-UI references this file itself for the current settings.
 There is no db component to this configuration setting.
 
 At this point the Rockstor Web-UI should be available to verify your changes.
-In our example setup the link on **laptop** would be `https://buildvm/ <https://buildvm/>`_.
+In our example setup the URL from **laptop** would be :code:`https://buildvm/`.
 
 It is very important to ensure that your code changes survive a reboot.
 Sometimes, especially when db changes are made, this can be an issue.
@@ -317,12 +347,16 @@ Changes fall into two main categories.
 1. Backend changes involving python coding.
 2. Frontend changes involving javascript, html and css.
 
-To test any change, you need to transfer files from your laptop to the VM::
+To test any change, you need to transfer files from your laptop to the VM:
+
+.. code-block:: console
 
         you@laptop:~> rsync -avz --exclude=.git ~/dev/rockstor-core/ root@buildvm:/opt/rockstor-dev/
 
 If you made any javascript, html or css changes,
-you need to collect the static files with the following after the above transfer::
+you need to collect the static files with the following after the above transfer:
+
+.. code-block:: console
 
         buildvm:~ # /opt/rockstor-dev/bin/buildout -c /opt/rockstor-dev/buildout.cfg install collectstatic
 
@@ -339,7 +373,9 @@ Consider having multiple terminals open simultaneously.
 - Another for browsing through the logs.
 
 When making backend changes, you may want to view/tail logs.
-Everything that your code or any rockstor service logs goes into the following logs: ::
+Everything that your code or any rockstor service logs goes into the following logs:
+
+.. code-block:: console
 
     buildvm:~ # ls -la /opt/rockstor-dev/var/log
     total 128
@@ -361,7 +397,9 @@ Everything that your code or any rockstor service logs goes into the following l
 rockstor.log should be the first place to look for errors or debug logs.
 
 Some things such as rockstor-pre/bootstrap are logged directly to the system log.
-And so are accessible via commands such as::
+And so are accessible via commands such as:
+
+.. code-block:: console
 
     journalctl  # akin to "less /var/log/messages" of old. N.B. cursor/page keys to navigate.
     journalctl -f  # tail system log
@@ -377,7 +415,9 @@ Adding third party Javascript libraries
 
 The frontend code uses third party javascript libraries such as jquery,bootstrap, d3 and many others.
 These are not part of the rockstor-core repository but are dynamically generated during the build.
-They are placed in the below directory on your build VM::
+They are placed in the below directory on your build VM:
+
+.. code-block:: console
 
     buildvm:~ # ls /opt/rockstor-dev/static/js/lib/
     additional-methods.min.js    cubism.v1.js                 jquery.flot.resize.js        jquery.validate.js
@@ -407,10 +447,10 @@ Database migrations
 -------------------
 
 We use `PostgreSQL10 <https://www.postgresql.org/>`_ as the database backend for Rockstor.
-There are two databases: ::
+There are two databases:
 
-    1. storageadmin
-    2. smart_manager
+1. storageadmin
+2. smart_manager
 
 Depending on your issue you may need to add a Django model, delete one, or change fields of an existing model.
 After editing models you need to create a database migration file and apply it.
@@ -422,22 +462,30 @@ Generate the migration on buildvm and copy the resulting file back to your lapto
 This migration file should now be added to the git soruce control.
 It represents a necessary part of your proposed changes and enables the update mechanism.
 
-E.g.for model changes in storageadmin application, create a migration file using: ::
+E.g.for model changes in storageadmin application, create a migration file using:
+
+.. code-block:: console
 
         buildvm:~ # /opt/rockstor-dev/bin/django makemigrations storageadmin
 
 The above command generates a migration file in
 :code:`/opt/rockstor-dev/src/rockstor/storageadmin/migrations/`. Apply the
-migration with::
+migration with:
+
+.. code-block:: console
 
         buildvm:~ # /opt/rockstor-dev/bin/django migrate storageadmin
 
 For model changes in the smart_manager application, create a migration file
-using::
+using:
+
+.. code-block:: console
 
         buildvm:~ # /opt/rockstor-dev/bin/django makemigrations smart_manager
 
-Run the migration with: ::
+Run the migration with:
+
+.. code-block:: console
 
         buildvm:~ # /opt/rockstor-dev/bin/django migrate --database=smart_manager smart_manager
 
@@ -447,7 +495,9 @@ Shipping changes
 ----------------
 
 As you continue to work on an issue, commit and push changes to the issue branch of your fork.
-You can periodically push your changes to GitHub with the following command: ::
+You can periodically push your changes to GitHub with the following command:
+
+.. code-block:: console
 
         you@laptop:~> cd ~/dev/rockstor-core; git push origin 1234_issue_title
 
@@ -480,11 +530,15 @@ Contributing and testing from another Rockstor contributor fork
 
 If you want to test and/or contribute starting from another user's fork, you can add his/her fork (or single branch).
 
-Adding another user's forked repo to your remotes: ::
+Adding another user's forked repo to your remotes:
+
+.. code-block:: console
 
         your@laptop:~/dev/rockstor-core> git remote add other_user_name git@github.com:other_user_name/rockstor-core.git
 
-Fetching another user's branch from the above added remote fork: ::
+Fetching another user's branch from the above added remote fork:
+
+.. code-block:: console
 
         your@laptop:~/dev/rockstor-core> git fetch other_user_name remote_branch_name
 

--- a/contribute/contribute.rst
+++ b/contribute/contribute.rst
@@ -4,33 +4,31 @@
 Contributing to Rockstor - Overview
 ===================================
 
-Rockstor is free and open source software and we are proud of our budding
-developer and user community. Anyone can contribute in a number of different
-ways.
+Rockstor is free and open source software and we are proud of our developer and user community.
+Anyone can contribute in a number of different ways.
 
 .. _storageexperts:
 
 Non developers
 --------------
 
-There is a lot you can do other than coding that is essential to the
-project. First, please join our `community discussion forum
-<https://forum.rockstor.com>`_. It's the central location where all discussions
-take place. If you need help, want to share an idea, suggest a new feature,
-etc..., the forum is a great place to start. Being active on the forum is very
-helpful to the project and the community as a whole.
+There is a lot you can do other than coding that is essential to the project.
+First, please join our `community discussion forum <https://forum.rockstor.com>`_.
+It's the central location where all discussions take place.
+If you need help, want to share an idea, suggest a new feature, etc...,
+the forum is a great place to start.
+Being active on the forum is very helpful to the project and the community as a whole.
 
-Contributions such as testing and reporting bugs are tremendously helpful and
-greatly appreciated. Please see our :ref:`update_channels` section and
-specifically the :ref:`testing_channel` sub section for information on how to
-track the latest fixes and features.
+Contributions such as testing and reporting bugs are tremendously helpful and greatly appreciated.
+Please see our :ref:`update_channels` section and specifically the :ref:`testing_channel`
+sub section for information on how to track the latest fixes and features.
 
-You can also contribute to the documentation of the project, which in many
-cases is crucial and often lags behind. So documentation contributions are
-also very much appreciated. For more information go to :ref:`contributedocs`
+You can also contribute to the documentation of the project.
+In many cases this is crucial and our documentation often lags behind the code.
+For more information see :ref:`contributedocs`
 
-Finally Rockstor's continued development and distribution depends on all those
-choosing to subscribe to the :ref:`stable_channel` updates where all the
+Finally Rockstor's continued development and distribution also depends on
+all those choosing to subscribe to the :ref:`stable_channel` updates where all the
 :ref:`testing_channel` work end up.
 
 .. _developers:
@@ -38,119 +36,113 @@ choosing to subscribe to the :ref:`stable_channel` updates where all the
 Developers
 ----------
 
-Developing Rockstor to deliver on its unique value proposition of being a
-Smart, Powerful, and Open storage platform is a major effort. If you are
-passionate about Open Source and Storage like us, you are in the right
-company. We welcome you to join our community. Please begin by joining our
-`community discussion forum <https://forum.rockstor.com>`_.
+Developing Rockstor as an open storage platform is non trivial endeavour.
+If you are passionate about Open Source and Storage like us, you are in the right place.
+The`community discussion forum <https://forum.rockstor.com>`_ is the place to start.
 
-Our development process is simple and straight forward. There is currently one
-main repository called `rockstor-core on Github
-<https://github.com/rockstor/rockstor-core>`_. Begin by `forking it
-<https://github.com/rockstor/rockstor-core/fork>`_.
+Our development process is relatively simple and straight forward.
+We use `Git <https://git-scm.com/>`_ for source code management and
+`Rockstor on Github <https://github.com/rockstor>`_ for issue tracking.
+There is currently one main code repository called
+`rockstor-core on Github <https://github.com/rockstor/rockstor-core>`_.
+Begin by `forking it <https://github.com/rockstor/rockstor-core/fork>`_ via GitHub's Web-UI.
 
-We use the wonderful `Git <https://git-scm.com/>`_ for source code
-management and `Rockstor on Github <https://github.com/rockstor>`_ for issue
-tracking. We'll assume you have basic proficiency with Git and are familiar
-with it using a text editor or IDE of your choice. Emacs, Vim,
-Eclipse and PyCharm are some recommendations. We'll further assume that you
-have your laptop ready with git and an editor installed.
+After you've forked the rockstor-core repo, clone your personal GitHub fork onto your laptop/desktop.
+The high level flow of an individual contribution is as follows.
 
-After you've forked the rockstor-core repo, clone the fork onto your
-laptop. The high level flow of a new contribution is as follows.
-
-1. Search for an existing issue or start a new issue using the `Issue
-Tracker <https://github.com/rockstor/rockstor-core/issues>`_.
-
-2. Make code changes
-.
-
-3. Submit your changes in a single `pull request
-<https://docs.github.com/en/github/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests>`_.
-
-4. Use the issue tracker for discussions as necessary
-.
-
-5. Close the issue when your pull request is merged
-.
+1. Search for an existing issue or start a new issue using the `Issue Tracker <https://github.com/rockstor/rockstor-core/issues>`_.
+2. Make and test code changes locally on a Rockstor install with the rpm package removed.
+3. Submit your changes in a single `pull request <https://docs.github.com/en/github/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests>`_.
+4. Use the issue tracker for discussions as necessary.
+5. Close the issue when your pull request is merged.
 
 Let's walk through this process in detail.
+
+.. _assumptions:
+
+Assumptions
+~~~~~~~~~~~
+
+In the following sections we assume:
+
+1. You have a basic working knowledge of the linux command line, git, and GitHub.
+2. **laptop** = your local laptop or desktop with git, ssh client, and an editor/IDE installed.
+3. **~/dev/rockstor-core**: = your (laptop/desktop) local git clone & dev branch directory.
+4. **buildvm**: is your target build machine's hostname; the name chosen during the rockstor install.
+
+TIP: you can add your buildvm's IP address to /etc/hosts on your laptop (linux assumed).
+An example IP entry would be (checked via :code:`grep "buildvm" /etc/hosts`)::
+
+    192.168.2.170   buildvm
+
+Then a :code:`ping -c2  buildvm` on your laptop should complete without error.
+And :code:`ssh root@buildvm` should provide a root user shell on the target buildvm machine.
+Assuming they are both on the same network.
 
 .. _localrepo:
 
 Local git repo setup
 --------------------
 
-Since we rely on github services, you need to create a profile on `github.com
-<https://github.com/>`_.
+Since we rely on GitHub services, you need to create a profile on `github.com <https://github.com/>`_.
 
-Go to `rockstor-core repo <https://github.com/rockstor/rockstor-core>`_ and
-click on the "Fork" button. This will fork the repository into your profile
-which serves as your private git remote called origin. The next few git steps
-are demonstrated on a Linux terminal. They work the same on a Mac too. Your IDE
-may have ways to completely avoid the terminal, but using the terminal makes
-you look cool:
+Go to `rockstor-core repo <https://github.com/rockstor/rockstor-core>`_ and click on the "Fork" button.
+You should then have a fork of this repository in your own GitHub profile.
+This repo then serves as your private git remote called origin.
+The next few git steps are demonstrated on a Linux terminal.
+They should also work with little or no modification in an OSX console.
 
-See YouTube `Trinity in the UNIX shell..... <https://www.youtube.com/watch?v=51lGCTgqE_w>`_.
+Clone, in turn, your GitHub profiles fork of rockstor-core onto your local machine.
+You can do this in any directory; but the following assume the ~/dev directory.
 
-Your development machine can be a Linux system or a Mac. In my case, it's a
-Lenovo laptop running Ubuntu. There are other contributors using Mac, so this
-process works the same in both cases.
+        you@laptop:~> mkdir ~/dev; cd ~/dev
+        you@laptop:~/dev> git clone https://github.com/your_github_username/rockstor-core.git
 
-Clone your fork of rockstor-core repo onto your local development
-environment. You can do this in any directory, but chances are you have a
-project directory appropriate for this. Let's assume you have a projects
-directory in your home(~/projects) for the repo. ::
+The above creates a local rockstor-core git repo in a new directory by
+the same name: "rockstor-core". Change into this new directory/repo clone via::
 
-        [you@your_laptop ~/projects]# git clone git@github.com:your_github_username/rockstor-core.git
-
-The above command creates a local rockstor-core git repo in a new directory by
-the same name(rockstor-core). Change into it::
-
-        [you@your_laptop ~/projects]# cd rockstor-core
+        you@laptop:~/dev> cd rockstor-core
 
 Configure this new git repo with your name and email address. This is required
 to accurately record collaboration::
 
-        [you@your_laptop rockstor-core]# git config user.name "Firstname Lastname"
-        [you@your_laptop rockstor-core]# git config user.email your_email_address
+        you@laptop:~/dev/rockstor-core> git config user.name "Firstname Lastname"
+        you@laptop:~/dev/rockstor-core> git config user.email your_email_address
 
-Add a remote called upstream to periodically rebase your local repository with
-changes in the upstream made by other contributors::
+Add a remote called **upstream** to periodically rebase your local repository with upstream changes by other contributors::
 
-        [you@your_laptop rockstor-core]# git remote add upstream https://github.com/rockstor/rockstor-core.git
+        you@laptop:~/dev/rockstor-core> git remote add upstream https://github.com/rockstor/rockstor-core.git
 
 .. _makechanges:
 
 Making changes
 --------------
 
-We'll assume you have identified an issue(eg: #1234) from the `github issue tracker
-<https://github.com/rockstor/rockstor-core/issues>`_ to work on. First, start
-with the latest code by rebasing your local repo's master branch with the
-upstream::
+Assuming you have identified or created an issue to work on (eg: #1234) from
+`GitHub issue tracker <https://github.com/rockstor/rockstor-core/issues>`_.
+First ensure your local code fork is up-to-date by rebasing on upstream::
 
-        [you@your_laptop rockstor-core]# git checkout master
-        [you@your_laptop rockstor-core]# git pull --rebase upstream master
+        you@laptop:~/dev/rockstor-core> git checkout master
+        you@laptop:~/dev/rockstor-core> git pull --rebase upstream master
 
-Checkout a new/separate branch for your issue. For example::
+Then checkout a new/issue-specific branch, e.g.::
 
-        [you@your_laptop rockstor-core]# git checkout -b issue#1234_brief_label
+        you@laptop:~/dev/rockstor-core> git checkout -b 1234_issue_title
 
-You can then start making changes in this branch.
+You can then start making changes in this dedicated branch.
 
-We strongly encourage you to commit changes a certain way to help other
-developers and keep the merge process smooth. As a guiding principle, separate
-your changes into one or more logically independent commits.
+We strongly encourage the following commit guidelines.
+As a guiding principle, separate your changes into one or more logically independent commits.
+This can help with the review process but only do this on larger more complex contributions.
+Otherwise we advise to squash your local 'working steps' commits into a single commit before submission.
 
-We request that you divide a commit message into three parts. Start the message
-with a single line summary, about 70 characters in length. Add a blank line
-after that. If you want to add more than a summary to your commit message,
-describe the change in more detail in plain text format where each line is no
-more than 80 characters. This description should be in present tense. Below is
-a fictional example::
+We request that you divide a commit message into two parts.
+Start the message with a single line summary, about 70 characters in length ending in #issue-number.
+Add a blank line after that.
+Further details can then follow in paragraphs less than 80 characters wide.
+Below is a fictional example::
 
-        foobar functionality for rockstor
+        foobar functionality for rockstor #1234
 
         Add a new file to implement the algorithm called recursive transaction
         launcher to generate transactional foobars recursively during runtime
@@ -165,232 +157,337 @@ a fictional example::
         #       new file:   foobar.py
         #
 
-If you'd like credit for your patch or if you are a frequent contributor, you
-should add your name to the `rockstor-core AUTHORS
-<https://github.com/rockstor/rockstor-core/blob/master/AUTHORS>`_ file.
+.. _buildvm:
 
 Build VM
 --------
 
-You need a Virtual Machine (VM) to build and test your changes. An easy
-solution is to create a Rockstor VM using either Oracle's `VirtualBox
-<https://www.virtualbox.org/>`_:
-
-See YouTube `Rockstor 3 0 installation demo <https://www.youtube.com/watch?v=00k_RwwC5Ms>`_.
-
-or if you are using a Linux desktop then `Virtual Machine Manager (VMM) <https://virt-manager.org>`_ is a more native option.
+You need a Virtual Machine (VM) to build and test your changes.
+An easy solution is to create a Rockstor VM using either Oracle's
+`VirtualBox <https://www.virtualbox.org/>`_
+or if you are using a Linux desktop then the
+`Virtual Machine Manager (VMM) <https://virt-manager.org>`_
+is a more native option.
 VMM is used in our :ref:`kvmsetup` howto.
-It need not be a VM, but using a physical machine just for this purpose could
-be overkill.
+A 'real' machine is another option and may be required in some scenarios,
+i.e. where a hardware compatibility feature is being developed.
 
+.. _buildvm_os:
 
-Note that when you first create the build VM, Rockstor rpm package will already
-be installed. The package files are located in /opt/rockstor. Further more, the
-Rockstor service should be running. We don't want that as it interferes with
-our development activity. Further down in this document, there is a buildout
-step. When that is run for the first time, the rpm package and it's effects are
-removed. Please note that this will destroy the existing Rockstor install and
-it's associated database details / settings.
+Build VM OS
+~~~~~~~~~~~
 
-Helpful terms
--------------
+It is suggested that a fresh Rockstor install be used for the target development machine OS.
+I.e. the resulting install from a
+`rockstor-installer <https://github.com/rockstor/rockstor-installer>`_
+Pre-built installers are available from our `Downloads page <https://rockstor.com/dls.html>`
+Only v4 "Built on openSUSE" and newer bases are considered.
+V3 and older (CentOS based) instances are now deprecated and no longer developed.
 
-In the following sections we use some terms in the commands; this is a short
-explanation of these terms:-
+N.B. the existing rpm based rockstor instance will be destroyed, hence the 'fresh' suggestion.
 
-1. **laptop**: This is your laptop or desktop computer.
+Alternatively an upstream (openSUSE) JeOS instance is also an option:
+but only if:
 
-2. **rockstor-core**: This is a directory on your laptop containing your local
-   rockstor-core repo. In my case, it's ~/Learnix/rockstor-core
+- It's root filesystem is btrfs and setup for boot to snapshot.
+- It uses NetworkManager not wicked for it's network configuration.
+- Shellinabox is installed and enabled/running under systemd.
+- Apparmour is disabled if installed: "systemctl disable apparmor".
 
-2. **build_vm**: IP address of your build VM. In my case, I use Virtualbox
-   with host-only adapter and get an ip in 192.168.56.101-254 range.
+.. _remove_rpm:
 
-3. **build_dir**: The directory on the build VM where you like to copy the code
-   to
-   and build. In my case, I picked /opt/build/.
+Remove the Existing Rockstor RPM install
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+The prior existing rpm install must be removed as it will otherwise interfere.
+The following does this, updates the os, and installs the dev dependencies.
+Around 30 packages will already be installed and a similar number will be added:
+if you are using the suggested rockstor-installer derived os instance.
+This change will be around 60 MB download and 250 MB installed. ::
+
+    zypper --non-interactive remove rockstor
+    rm -rf /opt/rockstor  # remove dangling rockstor rpm related files.
+    zypper refresh
+    zypper up --no-recommends
+    zypper --non-interactive install avahi samba docker nut nginx nfs-kernel-server \
+    at gcc python-devel gcc-c++ postgresql10-server libblkid-devel \
+    dnf-yum dnf-plugins-core python2-distro python3-distro firewalld python2-setuptools \
+    python2-requests python2-chardet python-xml cryptsetup which dnf-yum dnf-plugins-core \
+    python3-python-dateutil python2-six python2-psycopg2 python2-pyzmq python2-pyzmq-devel \
+    sssd sssd-tools sssd-ad sssd-ldap sssd-dbus python-dbus-python dmraid
+
+.. _buildvm_setup:
 
 Build VM initial setup
 ----------------------
 
-Transfer the code from your laptop to the build VM ::
+Transfer the code from your laptop to the build VM.
+A password will likely be requested and this is for the buildvm machine's root user.::
 
-        [you@laptop ]# rsync -avz --exclude=.git /path/to/rockstor-core/ root@build_vm:/path/to/build_dir/
+        you@laptop:~> rsync -avz --exclude=.git ~/dev/rockstor-core/ root@buildvm:/opt/rockstor-dev/
 
-If you are building for the first time or like a clean build, execute the
-following command in your deploy directory on the VM ::
+And via your ssh session to, or console on, **the target buildvm machine** (as root)::
 
-        [root@build_vm ]# python /path/to/build_dir/bootstrap.py -c /path/to/build_dir/buildout.cfg
+        buildvm:~ # zypper --non-interactive install python2-pip
+        buildvm:~ # pip2 install zc.buildout
 
-The next step is to build Rockstor with your new changes. This takes a long
-time for a clean build, but subsequent builds finish quickly ::
+We now have all the tools and code in place on the buildvm machine ready to:
 
-        [root@build_vm ]# /path/to/build_dir/bin/buildout -N -c /path/to/build_dir/buildout.cfg
+1. configure
+2. build
 
-Once the buildout step above succeeds, rockstor services are automatically
-started and managed by systemd. You should now be able to login to the WebUI
-and verify your changes.
+.. _code_config:
+
+1. Code configure/re-configure
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+::
+
+        buildvm:~ # cd /opt/rockstor-dev/
+        buildvm:/opt/rockstor-dev # buildout bootstrap
+
+.. _code_build:
+
+2. Code build
+~~~~~~~~~~~~~
+This step can take a few minutes, depending on cpu and internet speed.
+An internet connection is required as the process downloads all required Python eggs/wheels etc.
+We are running the bin/buildout script generated/updated in :ref:`code_config` step above.
+This stage takes considerably longer if you have also just configured/reconfigured the code.
+::
+
+         buildvm:/opt/rockstor-dev # bin/buildout -N -c buildout.cfg
+
+The build process, towards the end, enables and starts the following rockstor systemd services.
+**All are installed in /etc/systemd/system/**
+Note that all paths indicated are within the rockstor source tree.::
+
+    rockstor-pre.service  # starts bin/initrock after postgresql.service
+    rockstor  # starts bin/supervisord -c etc/supervisord.conf after rockstor-pre.service
+    rockstor-bootstrap  # starts bin/bootstrap after rockstor.service
+
+If a custom HDD power (APM) and/or spin-down setting is enabled, the following service is added.
+But only if the drive is confirmed as rotational.
+
+    rockstor-hdparm.service  # Configures drives APM & spindown settings via hdparm
+
+It is entirely safe to disable and delete the rockstor-hdparm.service.
+The only consequence is a return to defaults for all drives on next power cycle.
+N.B. power cycle, not necessarily reboot; as drive settings are often reboot sticky.
+And so require an actual power cycle to return to their.
+The rockstor-hdparm.service is our way to re-establish custom config on boot-up.
+The Rockstor Web-UI references this file itself for the current settings.
+There is no db component to this configuration setting.
+
+At this point the Rockstor Web-UI should be available to verify your changes.
+In our example setup the link on **laptop** would be `https://buildvm/ <https://buildvm/>`_.
+
+It is very important to ensure that your code changes survive a reboot.
+Sometimes, especially when db changes are made, this can be an issue.
+Be sure to check that the resulting build behaves as expected over:
+
+1. A config reset - removing /opt/rockstor-dev/.initrock and rebooting,
+2. Several reboots
+
+In (1.) above a db wipe is initiated helping to test the self-start code capability.
+See the initrock script and it's systemd trigger service: rockstor-init.
+
+A note on updating
+``````````````````
+A source install will consider any rpm version to be an update.
+And this 'update' will necessarily delete all prior settings / db setup.
+This is by design as a source release is intended only for development.
+Identifying itself as *ROCKSTOR UNKNOWN VERSION* withing the top-right of the Web-UI.
+For example if work on say a hardware compatibility issue is submitted,
+upon that work being merged and released in the next rpm version the author can 'update' in-place.
+There-by returning the specific hardware instance to a recognised upgrade path.
+Providing also for a double-check on if the released rpm, fix included, works as intended.
+The source install can, in-turn, now simply be removed via :code:`rm -rf /opt/rockstor-dev/`.
+Rpm installs live exclusively in /opt/rockstor, bar their associated systemd units.
+
+All :ref:`import_data` and :ref:`config_backup` functionality is supported similarly;
+as there is no source difference between a source and rpm install, just the packaging/update/support service.
+Unless of course there has been a breaking change involved in the submitted code.
+Breaking changes in these areas are strongly discouraged but unavoidable at time.
+An example: one cannot restore a new features settings to an older Rockstor instance.
 
 Change -> Test cycle
 --------------------
 
-Changes fall into two categories. (1) Backend changes involving python coding
-and (2) Frontend changes involving javascript, html and css.
+Changes fall into two main categories.
+
+1. Backend changes involving python coding.
+2. Frontend changes involving javascript, html and css.
 
 To test any change, you need to transfer files from your laptop to the VM::
 
-        [you@laptop ]# rsync -avz --exclude=.git /path/to/rockstor-core/ root@build_vm:/path/to/build_dir/
+        you@laptop:~> rsync -avz --exclude=.git ~/dev/rockstor-core/ root@buildvm:/opt/rockstor-dev/
 
-If you made any javascript, html or css changes, you need to collect static
-files with this command::
+If you made any javascript, html or css changes,
+you need to collect the static files with the following after the above transfer::
 
-        [root@build_vm ]# /path/to/build_dir/bin/buildout -c /path/to/build_dir/buildout.cfg install collectstatic
+        buildvm:~ # /opt/rockstor-dev/bin/buildout -c /opt/rockstor-dev/buildout.cfg install collectstatic
 
-Then, refresh the browser to test new changes in the WebUI. It's best to have
-aliases setup for above commands and have it all integrated into your
-editor(Emacs anyone?). At the very least you should have multiple terminal
-tabs open; one for transferring files, one for running commands on the VM, and
-another for browsing through the logs.
+N.B. An overall :ref:`code_config` may be required before this will work without error.
 
-When making backend changes, you may want to see debug logs and errors.
-Everything that you or any rockstor service logs goes into the following
-directory on your VM::
+Then, refresh the browser to test new changes in the Web-UI.
 
-    [root@build_vm ]# ls -l /path/to/build_dir/var/log
-    total 280
-    -rw-r--r-- 1 root root 106912 Jun 23 19:49 gunicorn.log
-    -rw-r--r-- 1 root root 119533 Jun 23 19:49 rockstor.log
-    -rw-r--r-- 1 root root     25 Jun 23 19:19 supervisord_data-collector_stderr.log
-    -rw-r--r-- 1 root root      0 Jun 23 15:33 supervisord_data-collector_stdout.log
-    -rw-r--r-- 1 root root      0 Jun 23 15:33 supervisord_gunicorn_stderr.log
-    -rw-r--r-- 1 root root      8 Jun 23 16:27 supervisord_gunicorn_stdout.log
-    -rw-r--r-- 1 root root  27980 Jun 23 19:49 supervisord.log
-    -rw-r--r-- 1 root root      0 Jun 23 15:33 supervisord_nginx_stderr.log
-    -rw-r--r-- 1 root root      0 Jun 23 15:33 supervisord_nginx_stdout.log
-    -rw-r--r-- 1 root root      0 Jun 23 15:33 supervisord_replication_stderr.log
-    -rw-r--r-- 1 root root      8 Jun 23 15:33 supervisord_replication_stdout.log
-    -rw-r--r-- 1 root root      0 Jun 23 15:33 supervisord_smart_manager_stderr.log
-    -rw-r--r-- 1 root root      8 Jun 23 15:33 supervisord_smart_manager_stdout.log
-    -rw-r--r-- 1 root root      0 Jun 23 15:33 supervisord_task-scheduler_stderr.log
-    -rw-r--r-- 1 root root      8 Jun 23 15:33 supervisord_task-scheduler_stdout.log
-    -rw-r--r-- 1 root root      0 Jun 23 15:33 supervisord_ztask-daemon_stderr.log
-    -rw-r--r-- 1 root root      0 Jun 23 15:33 supervisord_ztask-daemon_stdout.log
-    -rw-r--r-- 1 root root    996 Jun 23 19:49 ztask.log
+Terminal hint
+~~~~~~~~~~~~~
+Consider having multiple terminals open simultaneously.
+
+- One for transferring files.
+- One for running commands on the VM.
+- Another for browsing through the logs.
+
+When making backend changes, you may want to view/tail logs.
+Everything that your code or any rockstor service logs goes into the following logs: ::
+
+    buildvm:~ # ls -la /opt/rockstor-dev/var/log
+    total 128
+    drwxr-xr-x 1 root root    618 Nov 21 16:52 .
+    drwxr-xr-x 1 root root      6 Nov 21 16:51 ..
+    -rw-r--r-- 1 root root   1002 Nov 21 18:13 gunicorn.log
+    -rw-r--r-- 1 root root   1895 Nov 21 18:14 huey.log
+    -rw-r--r-- 1 root root 101124 Nov 21 18:27 rockstor.log
+    -rw-r--r-- 1 root root   1907 Nov 21 18:14 supervisord_data-collector_stderr.log
+    -rw-r--r-- 1 root root      0 Nov 21 16:52 supervisord_data-collector_stdout.log
+    -rw-r--r-- 1 root root   1388 Nov 21 18:14 supervisord_gunicorn_stderr.log
+    -rw-r--r-- 1 root root      0 Nov 21 16:52 supervisord_gunicorn_stdout.log
+    -rw-r--r-- 1 root root   2638 Nov 21 18:14 supervisord.log
+    -rw-r--r-- 1 root root    274 Nov 21 18:13 supervisord_nginx_stderr.log
+    -rw-r--r-- 1 root root      0 Nov 21 16:52 supervisord_nginx_stdout.log
+    -rw-r--r-- 1 root root    694 Nov 21 18:14 supervisord_ztask-daemon_stderr.log
+    -rw-r--r-- 1 root root      0 Nov 21 16:52 supervisord_ztask-daemon_stdout.log
 
 rockstor.log should be the first place to look for errors or debug logs.
 
-When making frontend changes, Developer Tools in Chrome/Firefox are your
-friends. You can `inspect elements
-<https://developer.chrome.com/docs/devtools/dom/>`_
-for html/css changes, log to the browser console from javascript code with
-console.log(), and use the debugger and step through javascript from your
-browser.
+Some things such as rockstor-pre/bootstrap are logged directly to the system log.
+And so are accessible via commands such as::
+
+    journalctl  # akin to "less /var/log/messages" of old. N.B. cursor/page keys to navigate.
+    journalctl -f  # tail system log
+    journalctl --no-pager  # to avoid line truncation.
+
+When making frontend changes, "Developer Tools" in Chrome/Firefox are critically important.
+You can `inspect elements <https://developer.chrome.com/docs/devtools/dom/>`_ for html/css changes.
+Log to the browser console from javascript code with console.log().
+And use the debugger to step through javascript; all from your browser.
 
 Adding third party Javascript libraries
 ---------------------------------------
 
-The frontend code uses third party javascript libraries such as jquery,
-bootstrap, d3 and many others. These are not part of the rockstor-core
-repository but are dynamically generated during the buildout step. They are
-placed in the below directory on your build VM::
+The frontend code uses third party javascript libraries such as jquery,bootstrap, d3 and many others.
+These are not part of the rockstor-core repository but are dynamically generated during the build.
+They are placed in the below directory on your build VM::
 
-    [root@build_vm ]# ls /path/to/build_dir/static/js/lib
-    backbone-0.9.2.js            cocktail.js   humanize.js                jquery.flot.stack.js         jquery.sparkline.min.js    json2.js              socket.io.min.js
-    backbone.routefilter.min.js  cron          jquery-1.9.1.min.js        jquery.flot.stackpercent.js  jquery.tablesorter.js      jsonform.js           underscore-1.3.2.js
-    bootstrap-datepicker.js      cubism.v1.js  jquery.flot.axislabels.js  jquery.flot.time.js          jquery.tools.min.js        later.min.js
-    bootstrap.js                 d3-tip.js     jquery.flot.js             jquery.flot.tooltip_0.5.js   jquery.touch-punch.min.js  moment.min.js
-    bootstrap-timepicker.js      d3.v3.min.js  jquery.flot.navigate.js    jquery-migrate-1.2.1.min.js  jquery-ui.min.js           prettycron.js
-    chosen.jquery.js             gentleSelect  jquery.flot.resize.js      jquery.shapeshift.js         jquery.validate.js         simple-slider.min.js
+    buildvm:~ # ls /opt/rockstor-dev/static/js/lib/
+    additional-methods.min.js    cubism.v1.js                 jquery.flot.resize.js        jquery.validate.js
+    backbone-0.9.2.js            d3-tip.js                    jquery.flot.stack.js         json2.js
+    backbone.routefilter.min.js  d3.v3.min.js                 jquery.flot.stackpercent.js  jsonform.js
+    bootstrap-datepicker.js      DataTables-addons            jquery.flot.time.js          later.min.js
+    bootstrap-editable.min.js    dataTables.bootstrap.min.js  jquery.flot.tooltip_0.5.js   LICENSE
+    bootstrap.js                 gentleSelect                 jquery.i18n                  moment.min.js
+    bootstrap-switch.min.js      handlebars-v4.0.5.js         jquery-migrate-1.2.1.min.js  prettycron.js
+    bootstrap-timepicker.js      humanize.js                  jquery.shapeshift.js         select2
+    Chart.min.js                 jquery-1.9.1.min.js          jquery.sparkline.min.js      simple-slider.min.js
+    chosen.jquery.js             jquery.dataTables.min.js     jquery.tablesorter.js        socket.io.min.js
+    clipboard.min.js             jquery.flot.axislabels.js    jquery.tools.min.js          socket.io.min.js.map
+    cocktail.js                  jquery.flot.js               jquery.touch-punch.min.js    underscore-1.3.2.js
+    cron                         jquery.flot.navigate.js      jquery-ui.min.js             underscore.js
 
-If you need to add a new library, place all of it's files in the lib
-directory(on the build VM, obviously) and continue your development
-process. After you open the pull request for rockstor-core repo, it's time to
-open a separate pull request for merging these libaries into upstream. This
-separate pull request must be opened for another repository named
-`rockstor-jslibs <https://github.com/rockstor/rockstor-jslibs>`_, which
-mirrors the contents of the lib directory shown above. The fork and
-pull-request process is same as it is for this(rockstor-core repo) one.
-
+If you need to add a new library,
+place all of it's files in the above lib directory (on buildvm) and continue your development process.
+After you open the pull request on the rockstor-core repo,
+it's time to open a separate pull request for merging the additional libaries.
+This separate pull request must be opened on another repository named
+`rockstor-jslibs <https://github.com/rockstor/rockstor-jslibs>`_,
+which mirrors the contents of the lib directory shown above.
+The fork and pull-request process for rockstor-jslibs is the same as for the rockstor-core repo.
 
 Database migrations
 -------------------
 
-We use `PostgreSQL <https://www.postgresql.org/>`_ as the database backend for
-Rockstor. There are two databases, (1) storageadmin and (2)
-smart_manager. Depending on your issue you may need to add a Django model,
-delete one, or change fields of an existing model. After editing models you
-need to create a migration and apply it.
+We use `PostgreSQL10 <https://www.postgresql.org/>`_ as the database backend for Rockstor.
+There are two databases: ::
 
-We used `South <https://south.aeracode.org/>`_ to manage database migrations for
-a while, but since updating to Django 1.8, migrations are natively
-supported. The steps have changed only slightly. Generate the migration on your
-VM and copy the migration file back to your laptop and add it in git once you
-are satisfied.
+    1. storageadmin
+    2. smart_manager
 
-For model changes in storageadmin application, create a migration file using
-::
+Depending on your issue you may need to add a Django model, delete one, or change fields of an existing model.
+After editing models you need to create a database migration file and apply it.
 
-        [root@build_vm ]# /path/to/build_dir/bin/django makemigrations storageadmin
+We used `South <https://south.aeracode.org/>`_ to manage database migrations for a while,
+but since updating to Django 1.8, migrations are natively supported.
+The steps have changed only slightly.
+Generate the migration on buildvm and copy the resulting file back to your laptop.
+This migration file should now be added to the git soruce control.
+It represents a necessary part of your proposed changes and enables the update mechanism.
+
+E.g.for model changes in storageadmin application, create a migration file using: ::
+
+        buildvm:~ # /opt/rockstor-dev/bin/django makemigrations storageadmin
 
 The above command generates a migration file in
-:code:`/path/to/build_dir/src/rockstor/storageadmin/migrations/`. Apply the
+:code:`/opt/rockstor-dev/src/rockstor/storageadmin/migrations/`. Apply the
 migration with::
 
-        [root@build_vm ]# /path/to/build_dir/bin/django migrate storageadmin
+        buildvm:~ # /opt/rockstor-dev/bin/django migrate storageadmin
 
 For model changes in the smart_manager application, create a migration file
 using::
 
-        [root@build_vm ]# /path/to/build_dir/bin/django makemigrations smart_manager
+        buildvm:~ # /opt/rockstor-dev/bin/django makemigrations smart_manager
 
-Run the migration with
-::
+Run the migration with: ::
 
-        [root@build_vm ]# /path/to/build_dir/bin/django migrate --database=smart_manager smart_manager
+        buildvm:~ # /opt/rockstor-dev/bin/django migrate --database=smart_manager smart_manager
 
 .. _shipchanges:
 
 Shipping changes
 ----------------
 
-As you continue to work on an issue, commit and push changes to the issue
-branch of your fork. You can periodically push your changes to github with the
-following command::
+As you continue to work on an issue, commit and push changes to the issue branch of your fork.
+You can periodically push your changes to GitHub with the following command: ::
 
-        [you@laptop ]# cd /path/to/rockstor-core; git push origin your_branch_name
+        you@laptop:~> cd ~/dev/rockstor-core; git push origin 1234_issue_title
 
-When you finish work for the issue and are ready to submit, create a pull
-request by clicking on the "pull request" button on github. This notifies the
-maintainers of your changes. As a best practice only open one pull request per
-issue containing all relevant changes.
+When you finish the associated issue changes, and are ready to submit your pull/merge reqeust,
+create a pull request by clicking on the "pull request" button on GitHub.
+This notifies the maintainers of your changes.
+As a best practice only open one pull request per issue containing all relevant changes.
 
 Commit history cleanup
 ----------------------
 
-As you work on an issue in your feature/issue branch, you may have committed
-multiple times. Please squash all these commits into one at the very end. This
-will keep the master branch's history clean and makes it easier to revert,
-search for a change or track a regression.
+As you work on an issue in your feature/issue branch, you may have committed multiple times.
+This is good practice as you have 'save points' and a backup of sorts.
+But submitting your pull request please squash all commits into one at the very end.
+Or if a pull request is non trivial, or spans multiple logically distinct areas.
+Try and squash your working commit history to a meaningfully, simple to understand, set.
+This will help to keep the upstream branch histories cleaner,
+and makes it easier to research, or revert, issue related changes.
+This can help a lot when tracking down regressions.
 
-Squashing commits into one is straight forward and most editors and IDEs with
-git support make it super easy to do so. If you've never done this before, this
+Squashing commits into one is relatively straight-forward.
+Most editors and IDEs with git intergration make this relatively easy to do so.
+If you've never done this before, this
 `short how-to <https://levelup.gitconnected.com/how-to-squash-git-commits-9a095c1bc1fc>`_
-is helpful.
+may help.
+See also `PyCharm's excellent git capabilities <https://www.jetbrains.com/help/pycharm/edit-project-history.html>`_.
 
 Contributing and testing from another Rockstor contributor fork
 ---------------------------------------------------------------
 
-If you want to test and/or contribute starting from another user fork,
-you can add his/her fork (or single branch)
+If you want to test and/or contribute starting from another user's fork, you can add his/her fork (or single branch).
 
-Adding another user forked repo to your remotes::
+Adding another user's forked repo to your remotes: ::
 
-        [you@laptop rockstor-core]# git remote add other_user_name git@github.com:other_user_name/rockstor-core.git
+        your@laptop:~/dev/rockstor-core> git remote add other_user_name git@github.com:other_user_name/rockstor-core.git
 
-Fetching another user branch::
+Fetching another user's branch from the above added remote fork: ::
 
-        [you@laptop rockstor-core]# git fetch other_user_name remote_branch_name
+        your@laptop:~/dev/rockstor-core> git fetch other_user_name remote_branch_name
 
-After fetching other contributor branch you can checkout it and start your
-coding or have a complete new branch starting from it. Github pull requests
-then can be directly to Rockstor repo or other user branches.
+After fetching another contributor's branch you can checkout from it and start your development,
+or create a complete new branch starting from one of theirs.
+Github pull requests can then be made directly to the Rockstor repo or other user's forks/branches.

--- a/contribute/contribute_documentation.rst
+++ b/contribute/contribute_documentation.rst
@@ -23,42 +23,41 @@ these steps:
 Go to `rockstor-doc repo <https://github.com/rockstor/rockstor-doc>`_ and click
 on the **Fork** button. This will fork the repository into your profile which
 serves as your private Git remote called *origin*. The next few Git steps are
-demonstrated on a Linux terminal. They work the same on a Mac too. Your IDE may
-have ways to completely avoid the terminal, but using the terminal makes you
-look cool.
+demonstrated on a Linux terminal. They work the same on a Mac too.
 
-.. code-block:: bash
+.. code-block:: console
 
-        git clone git@github.com:your_github_username/rockstor-doc.git
+        you@laptop:~> mkdir ~/dev; cd ~/dev
+        you@laptop:~/dev> git clone git@github.com:your_github_username/rockstor-doc.git
 
 The above command creates a local **rockstor-doc** Git repo in a new directory
-by the same name (rockstor-doc). Change into it.
+by the same name (rockstor-doc) inside the new "~/dev" directory. Change into it.
 
-.. code-block:: bash
+.. code-block:: console
 
-        [you@your_laptop ~/projects]# cd rockstor-doc
+         you@laptop:~/dev> cd rockstor-doc
 
 Configure this new Git repo with your name and email address. This is required
 to accurately record collaboration.
 
-.. code-block:: bash
+.. code-block:: console
 
-        [you@your_laptop rockstor-doc]# git config user.name "Firstname Lastname"
-        [you@your_laptop rockstor-doc]# git config user.email your_email_address
+        you@laptop:~/dev/rockstor-doc> git config user.name "Firstname Lastname"
+        you@laptop:~/dev/rockstor-doc> git config user.email your_email_address
 
 Add a remote called upstream to periodically rebase your local repository with
 changes in the upstream made by other contributors.
 
-.. code-block:: bash
+.. code-block:: console
 
-        [you@your_laptop rockstor-doc]# git remote add upstream https://github.com/rockstor/rockstor-doc.git
+        you@laptop:~/dev/rockstor-doc> git remote add upstream https://github.com/rockstor/rockstor-doc.git
 
 If desired, you can now verify these settings are correct by displaying the Git
 configuration for the local repository:
 
-.. code-block:: bash
+.. code-block:: console
 
-        [you@your_laptop rockstor-doc]# git config --list --local
+         you@laptop:~/dev/rockstor-doc> git config --list --local
 
 
 Installing Sphinx
@@ -84,9 +83,9 @@ it for :code:`make` to complete successfully.
 
 To install **sphinxext-rediraffe**, use this command:
 
-.. code-block:: bash
+.. code-block:: console
 
-        [you@your_laptop /path/to/rockstor-doc]# sudo pip3 install --user sphinxext-rediraffe
+        you@laptop:~/dev/rockstor-doc> sudo pip3 install --user sphinxext-rediraffe
 
 
 .. _dockersphinx:
@@ -113,16 +112,16 @@ one.
 First, start with the latest documentation by rebasing your local repo's master
 branch with the upstream.
 
-.. code-block:: bash
+.. code-block:: console
 
-        [you@your_laptop rockstor-doc]# git checkout master
-        [you@your_laptop rockstor-doc]# git pull --rebase upstream master
+        you@laptop:~/dev/rockstor-doc> git checkout master
+        you@laptop:~/dev/rockstor-doc> git pull --rebase upstream master
 
 Checkout a new/separate branch for your issue. For example:
 
-.. code-block:: bash
+.. code-block:: console
 
-        [you@your_laptop rockstor-doc]# git checkout -b issue#1234_brief_label
+        you@laptop:~/dev/rockstor-doc> git checkout -b issue#1234_brief_label
 
 You can then start making changes in this branch.
 
@@ -145,24 +144,24 @@ As you edit the content in *.rst* files, you can periodically generate HTML
 files and review them in your browser. To generate or update the HTML files,
 use the following command:
 
-.. code-block:: bash
+.. code-block:: console
 
-        [you@your_laptop /path/to/rockstor-doc]# make html
+        you@laptop:~/dev/rockstor-doc> make html
 
 If you use our :ref:`docker image<dockersphinx>`, you can use the following
 command:
 
-.. code-block:: bash
+.. code-block:: console
 
-        [you@your_laptop /path/to/rockstor-doc]# docker run --rm -v $PWD:/docs ghcr.io/rockstor/rockstor-doc:main make html
+        you@laptop:~/dev/rockstor-doc> docker run --rm -v $PWD:/docs ghcr.io/rockstor/rockstor-doc:main make html
 
 HTML files are generated in the :code:`_build/html` directory. From a separate
 terminal window, you can have a simple Python webserver always serving up this
 content with the following command:
 
-.. code-block:: bash
+.. code-block:: console
 
-        [you@your_laptop /path/to/rockstor-doc/_build/html]# python -m http.server 8000
+        you@laptop:~/dev/rockstor-doc> pushd ./_build/html; python3 -m http.server 8000; popd
 
 You can now go to :code:`http://localhost:8000` in your browser to review your
 changes. The webserver is to be started only once and it will continue to serve
@@ -184,9 +183,9 @@ Add and commit your changes
 
 First, let's add your changes:
 
-.. code-block:: bash
+.. code-block:: console
 
-        [you@your_laptop rockstor-doc]# git add new_file_added.rst existing_file.rst
+        you@laptop:~/dev/rockstor-doc> git add new_file_added.rst existing_file.rst
 
 
 Then, you can commit them. We strongly encourage you to commit changes in a
@@ -195,9 +194,9 @@ guidelines below pertain more to code contributions but feel free to be as
 perfect as you like. As a guiding principle, separate your changes into one or
 more logically independent commits.
 
-.. code-block:: bash
+.. code-block:: console
 
-        [you@your_laptop rockstor-doc]# git commit new_file_added.rst existing_file.rst
+        you@laptop:~/dev/rockstor-doc> git commit new_file_added.rst existing_file.rst
 
 We request that you divide a commit message into three parts. Start the message
 with a single line summary, about 50-70 characters in length. Add a blank line
@@ -206,7 +205,7 @@ describe the change in more detail in plain text format where each line is no
 more than 80 characters. This description should be in present tense. Below is
 a fictional example:
 
-.. code-block:: bash
+.. code-block:: console
 
         foobar functionality documentation for rockstor
 
@@ -238,15 +237,15 @@ to your *master* branch and automatically write redirections for pages that
 were renamed or relocated.
 To do so, you simply need to run the :code:`rediraffewritediff` builder:
 
-.. code-block:: bash
+.. code-block:: console
 
-        [you@your_laptop /path/to/rockstor-doc]# sphinx-build -b rediraffewritediff . _build/rediraffe
+        you@laptop:~/dev/rockstor-doc> sphinx-build -b rediraffewritediff . _build/rediraffe
 
 If you use the Docker image, you must use the following command:
 
-.. code-block:: bash
+.. code-block:: console
 
-        [you@your_laptop /path/to/rockstor-doc]# docker run --rm -v $PWD:/docs ghcr.io/rockstor/rockstor-doc:main sphinx-build -b rediraffewritediff . _build/rediraffe
+        you@laptop:~/dev/rockstor-doc> docker run --rm -v $PWD:/docs ghcr.io/rockstor/rockstor-doc:main sphinx-build -b rediraffewritediff . _build/rediraffe
 
 You should now see the needed redirects in :code:`redirects.txt`.
 
@@ -281,9 +280,9 @@ As you continue to work on an issue, commit and push your changes to the issue
 branch of your fork. You can periodically push your commits to Github with the
 following command:
 
-.. code-block:: bash
+.. code-block:: console
 
-        [you@your_laptop rockstor-doc]# git push origin your_branch_name
+        you@laptop:~/dev/rockstor-doc> git push origin your_branch_name
 
 
 


### PR DESCRIPTION
Due to a change/update in authentication mechanism re pypi we have had to alter our build procedure a little. Reflect these changes in our developer contributor section.

Fixes #319 
@FroggyFlox This ended up being far more extensive that I had originally thought.
Creating this pull reqeust to aid in further development / discussion if need be.
I have, potentially controversially, move to semantic line feeds. I'm rather hoping I can win you over on this one. Given my recent work on https://github.com/rockstor/rockstor-website/pull/22 I have found it to be far easier to work with when editing/writing and it should help with future edits and translations.
N.B. I have yet to do proper sphinx/formatting validation but will push any required changes that turn up.

## Includes improvements re:
- Brevity.
- Readability.
- Consistency.
- Ordering.
- Update to V4 "Built on openSUSE" base os.
- Preference for using a rockstor-installer derived instance.
- Removed dead and distracting YouTube links.
- Removed redundant and completely neglected AUTHORS link to rockstor-core.
- Better segregation and interdependency explanation of build steps.
- Improve on-boarding ease/speed via tips to enable cut-paste setups.
- Add info on associated systemd services.
- Add info on updating re rpm and source installs.
- Move contribute.rst to semantic line feeds.

## Testing.
The above changes were proofed vai the use of all included tips and suggestion so that an existing fresh UEFI install derived from our current latest pre-build installer (4.0.9-0 profile Leap15.3.x86_64) was transitioned into a development source install. Build from our current master branch.