### PR TITLE
Remove all YouTube links #309

### DIFF
--- a/howtos/boot_drive_howto.rst
+++ b/howtos/boot_drive_howto.rst
@@ -50,12 +50,9 @@ In this howto we will use `Linux Raid
 drive mirror. This can be done as part of Rockstor's installation but requires
 many more additional steps from a default, non mdraid, install. If you
 have never installed Rockstor before, we recommend you read our
-:ref:`quickstartguide`, also:
+:ref:`quickstartguide`.
 
-See YouTube `How to install Rockstor 3.8-7 <https://www.youtube.com/watch?v=yEL8xMhMctw>`_
-
-before proceeding with this howto as the default kickstarter based install
-method is recommended for most users.
+The default kickstarter based install method is recommended for most users.
 
 .. _mdraidos_requirements:
 

--- a/howtos/windows-shadow-copy.rst
+++ b/howtos/windows-shadow-copy.rst
@@ -29,8 +29,6 @@ should choose the *Snapshot prefix* field to be unique enough that it will not
 clash with directory or filenames. Eg: SNAPSHOT. The rest of the input in the
 form is same as it would be for any other Samba export.
 
-See YouTube `Rockstor shadow copy support part 1 of 3 <https://www.youtube.com/watch?v=XAe8OlO3O38>`_.
-
 Step 2: Schedule Snapshots
 --------------------------
 
@@ -39,8 +37,6 @@ do this by going to the *Scheduled Tasks* screen under the *System* tab and
 clicking the *Schedule a Task* button. The important input parameter here is
 the *Snapshot prefix*. It must be the same string from the previous step. Eg:
 SNAPSHOT. Choose rest of the input according to your needs.
-
-See YouTube `Rockstor shadow copy support part 2 of 3 <https://www.youtube.com/watch?v=kh4O11x5vy8>`_.
 
 
 Step 3: Access Snapshots from Windows
@@ -56,5 +52,3 @@ Share by the client. Meanwhile, Snapshots are taken on Rockstor periodically
 and result in *Previous versions* or *Shadow copies* for files. To access
 previous versions of a file from Windows, go to it's *Properties* window and
 click on *Previous Versions* tab.
-
-See YouTube `Rockstor shadow copy support part 3 of 3 <https://www.youtube.com/watch?v=_YxIEc0OD-M>`_.

--- a/installation/install.rst
+++ b/installation/install.rst
@@ -24,13 +24,6 @@ Quick evaluation using a virtual environment
 Rockstor can also be evaluated quickly using a virtual machine, see our
 :ref:`kvmsetup`.
 
-See YouTube `VirtualBox Rockstor install demo <https://www.youtube.com/watch?v=00k_RwwC5Ms>`_.
-
-Before proceeding with a serious installation that may require hardware
-procurement, you can evaluate Rockstor on Amazon AWS.
-
-See YouTube `Rockstor on ec2 <https://www.youtube.com/watch?v=ys_8FLVov2U>`_.
-
 Hardware recommendations
 -------------------------
 

--- a/interface/storage/file_sharing/nfs_ops.rst
+++ b/interface/storage/file_sharing/nfs_ops.rst
@@ -36,8 +36,6 @@ of shares are made accessible via chosen options. Go to the *NFS* view under
 the *Storage* tab of the Web-UI and click on **Add NFS Export** button to add
 a new NFS export.
 
-See YouTube `Create NFS export of a share <https://www.youtube.com/watch?v=4xRsIIbXYXI>`_.
-
 Various fields of the form are explained as follows.
 
 * **Shares to export**: Choose one or more shares to be exported.
@@ -54,8 +52,6 @@ An NFS export can be edited to add or remove a Share or allow different set of
 clients to be able to access it. In the displayed table of NFS exports under
 the *NFS* view of the Web-UI, click on the **edit** icon of the corresponding
 export to edit.
-
-See YouTube `Edit NFS export of a share <https://www.youtube.com/watch?v=OSs6BteniX0>`_.
 
 Delete NFS export
 ^^^^^^^^^^^^^^^^^

--- a/interface/storage/file_sharing/samba_ops.rst
+++ b/interface/storage/file_sharing/samba_ops.rst
@@ -33,8 +33,6 @@ Set *Guest OK* to *yes* if you want to permit guest access.
 
 Set *Read only* to *yes* if the share should not be writable by clients.
 
-See YouTube `Create a Samba SMB export of a share <https://www.youtube.com/watch?v=hZ7FQWuF6TI>`_.
-
 View Samba Export
 ^^^^^^^^^^^^^^^^^
 

--- a/interface/storage/pools-btrfs.rst
+++ b/interface/storage/pools-btrfs.rst
@@ -27,8 +27,6 @@ Click on **Create Pool** button and submit the create pool form to create a
 pool. There is a tooltip for each input field to help you choose appropriate
 parameters.
 
-See YouTube `Creating a Pool <https://www.youtube.com/watch?v=T5sg8xSoH1E>`_.
-
 
 .. _redundancyprofiles:
 
@@ -154,16 +152,12 @@ Redundancy profile changes
 
 You can change :ref:`redundancyprofiles` online with very few restrictions.
 
-See YouTube `Change Pool's RAID profile <https://www.youtube.com/watch?v=DouOx8gX5yE>`_.
-
 .. _pooladddisks:
 
 Adding Disks
 ^^^^^^^^^^^^
 
 Disks can be added to a Pool online and expand capacity.
-
-See YouTube `Adding disks to a Pool <https://www.youtube.com/watch?v=E37rzWcwGu0>`_.
 
 .. _poolremovedisks:
 
@@ -173,8 +167,6 @@ Removing Disks
 Disks can be removed from a Pool online similar to adding Disks. However, since
 it results in reduced capacity, this operation can succeed only if the
 resulting capacity after removal is greater than the current usage.
-
-See YouTube `Removing disks from a Pool <https://www.youtube.com/watch?v=535pxsF16Pk>`_.
 
 
 Pool deletion

--- a/interface/storage/shares-btrfs-subvolumes.rst
+++ b/interface/storage/shares-btrfs-subvolumes.rst
@@ -24,8 +24,6 @@ grow and shrink capacity at a later time. Click on **Create Share** button and
 submit the Share creation form to create one. There is a tooltip for each input
 field to help you choose appropriate parameters.
 
-See YouTube `Create a Rockstor Share <https://www.youtube.com/watch?v=k537gsx8ifQ>`_.
-
 .. _resizeshare:
 
 Resizing a share
@@ -33,8 +31,6 @@ Resizing a share
 
 A share can be resized by increasing or decreasing it's provisioned
 capacity. To resize a Share, Click the **Resize** button in it's detail screen.
-
-See YouTube `Resize a Rockstor Share <https://www.youtube.com/watch?v=vMCNZFDwKLQ>`_.
 
 Note that a share cannot be decreased to a capacity lower than it's current
 usage. Internally, Share capacity enforcement is done via BTRFS qgroup feature
@@ -82,7 +78,5 @@ created from, at the time that it was created.
 In Rockstor, both Shares and Snapshots can be cloned to create new Shares.
 
 To clone a Share, got to it's detail screen and click on the **Clone** button.
-
-See YouTube `Clone a Share <https://www.youtube.com/watch?v=DhXUyDoBVMY>`_.
 
 To clone a Snapshot, see :ref:`clonesnapshot`.

--- a/interface/storage/snapshots-btrfs-snapshots.rst
+++ b/interface/storage/snapshots-btrfs-snapshots.rst
@@ -42,8 +42,6 @@ To create a Snapshot, use the **Create Snapshot** button and submit the form
 with your chosen input values. There is a tooltip for each input field with
 more help.
 
-See YouTube `Create a Snapshot <https://www.youtube.com/watch?v=QTQePwrYMS0>`_.
-
 
 .. _schedulesnapshot:
 
@@ -53,8 +51,6 @@ Scheduling Snapshots
 Using Rockstor's :ref:`tasks` system it is also possible to schedule Snapshot
 creation automatically at a predefined time and frequency similar to cronjobs
 in Linux. To find out more, see :ref:`snapshottask`.
-
-See YouTube `Schedule a Snapshot <https://www.youtube.com/watch?v=PA0hneCq-AE>`_.
 
 You can also schedule Snapshots such that the frequency decreases over
 time. For example, you can schedule 12 hourly Snapshots during the day, 4
@@ -85,8 +81,6 @@ wish to create a new Share that is an exact copy of the Snapshot.
 To clone a Snapshot, click on the clone icon in the **Actions** column of the
 Snapshot table.
 
-See YouTube `Clone a Snapshot <https://www.youtube.com/watch?v=aySlQCx65GM>`_.
-
 To clone a Share, see :ref:`cloneshare`.
 
 .. _rollingbackshare:
@@ -98,8 +92,6 @@ A Share can be rolled back to any of its snapshots. This is useful if you wish
 to restore a Share to it's previous state represented by its snapshots
 
 Click on the **Rollback** button in the Share's detail screen.
-
-See YouTube `Rollback a Share to a specific Snapshot <https://www.youtube.com/watch?v=r0SbCZ_kEBg>`_.
 
 .. note::
   Shares that are exported through NFS or Samba cannot be rolled back. The NFS

--- a/interface/uis.rst
+++ b/interface/uis.rst
@@ -44,7 +44,5 @@ must be created by entering desired credentials. In the second screen, all
 disks detected in the system are displayed. Click next to finish the setup
 process.
 
-See YouTube `Rockstor Web UI <https://www.youtube.com/watch?v=MvdkoPeTLm8>`_.
-
 Once the setup process is complete, the newly created admin user is logged in
 and the Rockstor :ref:`dashboard` is displayed.

--- a/themes/rockstor/layout.html
+++ b/themes/rockstor/layout.html
@@ -60,15 +60,10 @@
                 <li>&nbsp;</li>
                 <li>&nbsp;</li>
 
-                <li style="display: inline-block"><span class="social_icons"><a href="https://twitter.com/rockstorinc" target="_blank"><i
-                        class="fa fa-twitter"></i></a></span></li>
-                <li style="display: inline-block"><span class="social_icons"><a href="https://www.linkedin.com/company/rockstor-inc-?trk=tyah"
-                                                  target="_blank"><i
-                        class="fa fa-linkedin"></i></a></span></li>
                 <li style="display: inline-block"><span class="social_icons"><a href="https://github.com/rockstor" target="_blank"><i
                         class="fa fa-github"></i></a></span></li>
-                <li style="display: inline-block"><span class="social_icons"><a href="https://www.youtube.com/user/rockstorinc" target="_blank"><i
-                        class="fa fa-youtube-play"></i></a></span></li>
+                <li style="display: inline-block"><span class="social_icons"><a href="https://twitter.com/rockstor4" target="_blank"><i
+                        class="fa fa-twitter"></i></a></span></li>
             </ul>
 
         </div>


### PR DESCRIPTION
Remove all YouTube links as the vast majority are no longer available and so represent dead links.

Fixes #309

## Also includes:
- Removal of YouTube header link.
- Removal of Linkedin header link.
- Updating of Twitter link in header.
- Re-arrangement of remaining header links to match current website.
