### PR TITLE
Explicitly detail the recommendations for the rock-ons root share (#340)

### DIFF
--- a/interface/overview.rst
+++ b/interface/overview.rst
@@ -45,7 +45,7 @@ We recommend creating a *dedicated* share to be used as the rock-ons root.
 While any share can be chosen as the rock-ons root, we **strongly** recommend
 to create a share to be used *only* as the rock-ons root to prevent any
 conflict that may arise with a mixed-used share. The rock-ons root share is
-indeed used by Docker to store permanent data such as images and container
+used by Docker to store permanent data such as images and container
 layers. As a result, any conflict or alteration of these data that might result
 from a mixed used share has the potential to break the installed Rock-ons.
 Note also that the rock-ons root share can be part of any :ref:`pool<pools>`

--- a/interface/overview.rst
+++ b/interface/overview.rst
@@ -52,7 +52,7 @@ Note also that the rock-ons root share can be part of any :ref:`pool<pools>`
 and does not require the creation of a dedicated pool.
 
 .. note::
-    While it is possible to use the existing 'out of the box' home share but
+    While it is possible to use the existing 'out of the box' home share
     this is **not recommended** for the reason described above. Similarly,
     while it is possible to create the rock-ons root share on the system pool,
     this is **not recommended** either.

--- a/interface/overview.rst
+++ b/interface/overview.rst
@@ -40,11 +40,25 @@ The Rock-ons root
 All Rock-ons require the **Rock-on service** to be enabled and prior to
 enabling this service it must be configured. This is a simple matter of
 configuring a sufficiently large share for the rock-ons to be installed into.
-It is possible to use the existing 'out of the box' home share but this is not
-recommended.
 
-The following shows a **Recommended Minimum 5 GB rock-ons-root** share backed
-by a previously created pool named **rock-pool**.
+We recommend creating a *dedicated* share to be used as the rock-ons root.
+While any share can be chosen as the rock-ons root, we **strongly** recommend
+to create a share to be used *only* as the rock-ons root to prevent any
+conflict that may arise with a mixed-used share. The rock-ons root share is
+indeed used by Docker to store permanent data such as images and container
+layers. As a result, any conflict or alteration of these data that might result
+from a mixed used share has the potential to break the installed Rock-ons.
+Note also that the rock-ons root share can be part of any :ref:`pool<pools>`
+and does not require the creation of a dedicated pool.
+
+.. note::
+    While it is possible to use the existing 'out of the box' home share but
+    this is **not recommended** for the reason described above. Similarly,
+    while it is possible to create the rock-ons root share on the system pool,
+    this is **not recommended** either.
+
+As an example, the following shows a **Recommended Minimum 5 GB rock-ons-root**
+share backed by a previously created pool named **rock-pool**.
 
 .. image:: /images/interface/docker-based-rock-ons/rockons_root_share.png
    :width: 100%


### PR DESCRIPTION
Fixes #340 
@phillxnet, ready for review.

### This pull request's proposal
This pull request proposes to slightly improve the recommendations on the creation of the Rock-ons root share to improve clarity. It essentially:
- explicitly state that the rock-ons root can have any name
- recommend to create a dedicated share for it (and provides a brief explanation)
- explicitly state that the rock-ons root share can be part of any pool


### Checklist
- [x] With the proposed changes no Sphinx errors or warnings are generated.
- [x] I have added my name to the AUTHORS file, if required (descending alphabetical order).