### PR TITLE
Update filesystems repo url in Stable Kernel Backport howto #349

### DIFF
--- a/howtos/stable_kernel_backport.rst
+++ b/howtos/stable_kernel_backport.rst
@@ -71,7 +71,7 @@ Keeping both in sync is important, especially in the context of Rockstor's NAS f
 .. code-block:: console
 
     zypper --non-interactive addrepo --refresh https://download.opensuse.org/repositories/Kernel:/stable:/Backport/standard/ Kernel_stable_Backport
-    zypper --non-interactive addrepo --refresh https://download.opensuse.org/repositories/filesystems/openSUSE_Leap_15.3/ filesystems
+    zypper --non-interactive addrepo --refresh https://download.opensuse.org/repositories/filesystems/15.3/ filesystems
     zypper --non-interactive --gpg-auto-import-keys refresh
 
 .. _kernel_stable_repo:


### PR DESCRIPTION
Update the filesystems repo url, for btrfs-progs, in accordance with recent upstream changes.

Fixes #349

### Checklist
- [x] With the proposed changes no Sphinx errors or warnings are generated.
- [x] I have added my name to the AUTHORS file, if required (descending alphabetical order).