### PR TITLE
Remove hard-coded price and currency for the Stable subscription #363

### DIFF
--- a/interface/docker-based-rock-ons/netdata_official.rst
+++ b/interface/docker-based-rock-ons/netdata_official.rst
@@ -14,7 +14,7 @@ requirements.
 What is Netdata
 ---------------
 
-`Netdata <https://www.netdata.cloud/product/>`_ Agent is a free an open-source
+`Netdata <https://www.netdata.cloud/agent>`_ Agent is a free an open-source
 tool to monitor and analyze the performance of your system in real time. It
 gathers a wealth of metrics from the operating system, hardware, as well as
 applications (including rock-ons), and display them in a modern and descriptive

--- a/interface/system/update_channels.rst
+++ b/interface/system/update_channels.rst
@@ -107,11 +107,13 @@ patient as we work our the teething problems expected with newly release
 systems. Specific documentation will follow once we have established the less
 self explanatory elements.
 
-Participation in the stable channel is key to the future of Rockstor
-development. The ability to continue to improve and provide future-proof
-services, by way of advanced file system facilities made easy, is dependant on
-a financial component. The stable channel is that financial component.
-Currently a one-year subscription costs £20.00 (GBP).
+Participation in the stable channel is key to the future of Rockstor development.
+The ability to continue to improve and provide future-proof services,
+by way of advanced file system facilities made easy, is dependant on a financial component.
+The stable channel, and it's associated
+`Commercial Support <https://rockstor.com/commercial_support.html>`_
+option, is that financial component.
+See our `Shop <https://shop.rockstor.com/>`_ for the current cost of a **Stable Updates subscription**.
 
 Please keep an eye on our `friendly forum <https://forum.rockstor.com/>`_ as
 discount / promotional codes are occasionally issued.


### PR DESCRIPTION
Adds instead a link to our shop, along with an indication of the associated commercial support and it's dedicated URL on the main site.

N.B. The paragraph concerned was reformatted using Semantic Linefeeds.

## Includes
- Unrelated netdata 404 URL fix.

Fixes #363

### Checklist
- [x] With the proposed changes no Sphinx errors or warnings are generated.
- [x] I have added my name to the AUTHORS file, if required (descending alphabetical order).