### PR TITLE
Correct Docker image tag to `master` (#385)

### DIFF
--- a/contribute/contribute_documentation.rst
+++ b/contribute/contribute_documentation.rst
@@ -153,7 +153,7 @@ command:
 
 .. code-block:: console
 
-        you@laptop:~/dev/rockstor-doc> docker run --rm -v $PWD:/docs ghcr.io/rockstor/rockstor-doc:main make html
+        you@laptop:~/dev/rockstor-doc> docker run --rm -v $PWD:/docs ghcr.io/rockstor/rockstor-doc:master make html
 
 HTML files are generated in the :code:`_build/html` directory. From a separate
 terminal window, you can have a simple Python webserver always serving up this
@@ -245,7 +245,7 @@ If you use the Docker image, you must use the following command:
 
 .. code-block:: console
 
-        you@laptop:~/dev/rockstor-doc> docker run --rm -v $PWD:/docs ghcr.io/rockstor/rockstor-doc:main sphinx-build -b rediraffewritediff . _build/rediraffe
+        you@laptop:~/dev/rockstor-doc> docker run --rm -v $PWD:/docs ghcr.io/rockstor/rockstor-doc:master sphinx-build -b rediraffewritediff . _build/rediraffe
 
 You should now see the needed redirects in :code:`redirects.txt`.
 


### PR DESCRIPTION
Fixes #385 
@phillxnet, ready for review.

### This pull request's proposal
This PR simply proposes to correct the tag listed in our docs for our Docker image from `main` to `master` as the latter is now what is listed in our repo:
![image](https://user-images.githubusercontent.com/30297881/174144220-d2a6c1b4-efe5-4c8d-b747-f5f3d87b3e9f.png)
https://github.com/rockstor/rockstor-doc/pkgs/container/rockstor-doc

### Checklist
- [X] With the proposed changes no Sphinx errors or warnings are generated.
- [X] I have added my name to the AUTHORS file, if required (descending alphabetical order).