### PR TITLE
Treat warnings as errors when building docs #407

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -13,7 +13,7 @@ jobs:
     - name: install sphinxext-rediraffe
       run: pip3 install sphinxext-rediraffe
     - name: build docs
-      run: make html
+      run: sphinx-build -b html -E -W --keep-going . _build/html
 
   linkcheck:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Fixes #407
@phillxnet, ready for review. 

### This pull request's proposal
We currently only use the default build options with `make html`. Switch to manually defining the `sphinx-build` command to use additional options. -E to use a clean environment every time, -W to treat warnings as errors and thus make the Github action fail (more easily detected), and --keep-going to list all warnings in a single run.

### Testing
This branch was tested by creating a PR against my fork's master branch, which triggered the updated Github action. That branch contained 2 instances of underlines shorter than their title (similar to warnings in #406). This led to:
```
2023-01-28T16:27:55.9424206Z ##[group]Run sphinx-build -b html -E -W --keep-going . _build/html
(...)
2023-01-28T16:27:58.5238661Z /home/runner/work/rockstor-doc/rockstor-doc/data_loss.rst:4: WARNING: Title underline too short.
2023-01-28T16:27:58.5238941Z 
2023-01-28T16:27:58.5239151Z 
2023-01-28T16:27:58.5239546Z Data Loss-prevention and Recovery in Rockstor
2023-01-28T16:27:58.5240138Z ==================================
2023-01-28T16:27:58.5240745Z /home/runner/work/rockstor-doc/rockstor-doc/data_loss.rst:44: WARNING: Title underline too short.
2023-01-28T16:27:58.5241009Z 
2023-01-28T16:27:58.5241108Z Pool drive count advice
(...)
2023-01-28T16:28:01.1993940Z build finished with problems, 2 warnings.
2023-01-28T16:28:01.2975596Z ##[error]Process completed with exit code 1.
```

The "checks" summary thus looked like:
![image](https://user-images.githubusercontent.com/30297881/215278318-b59bef8e-f55b-458c-95e9-52b677d88fc0.png)


### Checklist
- [x] With the proposed changes no Sphinx errors or warnings are generated.
- [x] I have added my name to the AUTHORS file, if required (descending alphabetical order).