### PR TITLE
Tweak 'Code test' re missing settings env and hard-reset #414

### DIFF
--- a/contribute/contribute.rst
+++ b/contribute/contribute.rst
@@ -344,10 +344,13 @@ In our example setup, the URL from **laptop** would be :code:`https://buildvm/`.
 
 It is very important to ensure that your code changes survive a reboot.
 Sometimes, especially when database changes are made, this can be an issue.
-Be sure to check that the resulting build behaves as expected over:
+Be sure to also check that the resulting build behaves as expected over a hard-reset:
 
-1. A config reset - removing :code:`/opt/rockstor/.initrock` and rebooting
-2. Several reboots
+  1. Do a total config reset by removing :code:`/opt/rockstor/.initrock` and rebooting.
+  2. Redo the :ref:`webui_setup` :code:`userdel username` first if reusing username.
+
+.. note::
+    Ensure all is as expected over **several reboots** there-after.
 
 In (1.) above, a database wipe is initiated helping to test the self-start code capability.
 See the :code:`initrock.py` script and its systemd trigger service: :code:`rockstor-pre.service` for more details.
@@ -363,9 +366,10 @@ The following will run all tests following the source installation detailed abov
 .. code-block:: text
 
     buildvm:~ # cd /opt/rockstor/src/rockstor
+    buildvm:~ # export DJANGO_SETTINGS_MODULE=settings
     buildvm:/opt/rockstor/src/rockstor # poetry run django-admin test -v 2
 
-All included tests, **numbering over 200**, are expected to pass;
+All included tests, **numbering over 240**, are expected to pass;
 however, it is always worth checking our `current issues <https://github.com/rockstor/rockstor-core/issues>`_
 for known failures in this area.
 

--- a/contribute/contribute.rst
+++ b/contribute/contribute.rst
@@ -347,7 +347,8 @@ Sometimes, especially when database changes are made, this can be an issue.
 Be sure to also check that the resulting build behaves as expected over a hard-reset:
 
   1. Do a total config reset by removing :code:`/opt/rockstor/.initrock` and rebooting.
-  2. Redo the :ref:`webui_setup` :code:`userdel username` first if reusing username.
+  2. Delete the Rockstor admin user: :code:`userdel username`.
+  3. Redo the :ref:`webui_setup` .
 
 .. note::
     Ensure all is as expected over **several reboots** there-after.

--- a/installation/installer-howto.rst
+++ b/installation/installer-howto.rst
@@ -203,10 +203,14 @@ Then "Accept the Risk and Continue".
 You can use a 'real' domain certificate with Rockstor but this is an advanced
 topic beyond the scope of this installer guide.
 
+.. _webui_setup:
+
 Rockstor Setup and EULA
 ^^^^^^^^^^^^^^^^^^^^^^^
 The following shows example entries for this initial Web-UI setup screen, they
 are blank by default.
+
+.. note:: An unprivileged linux user will also be created by this step (UID=1000 GID=100).
 
 .. image:: /images/installation/installer-howto/initial_rockstor_setup_screen.png
    :width: 100%


### PR DESCRIPTION
Fixes #414

### This pull request's proposal
We were missing a DJANGO_SETTINGS_MODULE env in this section, and have previously neglected to reference the creation of an OS user during our Web-UI setup procedure.

#### Includes
- Update to installer-howto.rst re new internal link used in the above additions and the normal user creation with their out-of-the-box UID/GID specified.
- Update to the number of unit tests.

### Checklist
- [x] With the proposed changes no Sphinx errors or warnings are generated.
- [x] I have added my name to the AUTHORS file, if required (descending alphabetical order).