### PR TITLE
 Add how-to for RPM install on Leap base #421

### DIFF
--- a/howtos.rst
+++ b/howtos.rst
@@ -7,6 +7,7 @@ How-tos & Guides
 
    howtos/stable_kernel_backport
    howtos/15-2_to_15-3
+   howtos/rpm_install
    howtos/v3_to_v4
    howtos/reinstall
    howtos/disk_power_down

--- a/howtos/rpm_install.rst
+++ b/howtos/rpm_install.rst
@@ -1,0 +1,65 @@
+.. _rpm_install:
+
+Install on Vanilla openSUSE/SuSE SLES
+=====================================
+
+Our installer profiles (`<https://github.com/rockstor/rockstor-installer>`_), and consequently our pre-built installers, deviate only a little from openSUSE’s JeOS appliance profiles.
+As a result, it is possible to manually configure a Vanilla openSUSE/SuSE SLES based install to then install Rockstor's rpm.
+
+.. warning::
+
+    **For advanced users only**
+
+    This install method is predominantly for developers or advanced users and will likely require additional maintenance.
+    It may also serve as an option where a SLES base is required. Please note our undesirable disabling of apparmor.
+    We hope to resolve this partial failure in due time.
+
+The procedure, not recommended or supported, consists in adding the relevant Rockstor repositories to a dedicated vanilla openSUSE / SuSE SLES non transactional server install.
+The base OS version is assumed to be already found within our Rockstor 4 `Installer Recipes <https://github.com/rockstor/rockstor-installer>`_, and in the case of SLES, to be at least version 15.4--when the upstream binary compatibility between openSUSE Leap & SuSE SLES matured.
+
+.. _rpm_install_procedure:
+
+Procedure
+---------
+
+The relevant commands (assuming a 15.4 base version) are as follows:
+
+First, disable :code:`apparmor`.
+
+.. code-block:: console
+
+    systemctl disable apparmor
+
+Then, ensure :code:`NetworkManager` is installed and running.
+
+.. code-block:: console
+
+    zypper install --no-recommends NetworkManager
+    systemctl disable wicked
+    systemctl enable NetworkManager
+    systemctl start NetworkManager
+
+Define and instantiate the rpm repositories required by Rockstor (all are multiarch).
+
+.. code-block:: console
+
+    zypper --non-interactive addrepo --refresh -p105 https://download.opensuse.org/repositories/home:/rockstor/15.4/ home_rockstor
+    zypper --non-interactive addrepo --refresh -p97 https://download.opensuse.org/repositories/home:/rockstor:/branches:/Base:/System/15.4/ home_rockstor_branches_Base_System
+    rpm --import https://raw.githubusercontent.com/rockstor/rockstor-core/master/conf/ROCKSTOR-GPG-KEY
+    zypper addrepo -f http://updates.rockstor.com:8999/rockstor-testing/leap/15.4/ Rockstor-Testing
+    zypper --non-interactive --gpg-auto-import-keys refresh
+
+Finally, install and start Rockstor.
+
+.. code-block:: console
+
+    zypper in --no-recommends rockstor-4.5.8-0
+    systemctl enable --now rockstor-bootstrap
+
+.. warning::
+
+    Please note that Rockstor is not yet Multi-path controller compatible.
+
+.. note::
+    Please visit our `friendly forum <https://forum.rockstor.com/>`_ for questions and suggestions for improving these instructions.
+    As always, GitHub pull requests are welcome: `<https://github.com/rockstor/rockstor-doc>`_.


### PR DESCRIPTION
Fixes #421 
@phillxnet, ready for review.


### This pull request's proposal
We currently have these instructions in the Downloads page of our website.
It would be beneficial to host these instructions as a how-to in our docs instead.

@phillxnet, I was wondering whether to link to this new how-to from our current sections related to Installation. However, given we do not recommend or support these instructions, I ended up refraining myself from doing so. This new document is of course listed in the menu/table of contents, though. Let me know if you would prefer seeing it linked to directly from somewhere in the docs.

### Checklist
- [x] With the proposed changes no Sphinx errors or warnings are generated.
- [x] I have added my name to the AUTHORS file, if required (descending alphabetical order).