### PR TITLE
Update Documentation Copyright/Year (431)

### DIFF
--- a/themes/rockstor/layout.html
+++ b/themes/rockstor/layout.html
@@ -114,7 +114,7 @@
         <div id="footer">
             <div class="row-fluid">
                 <div id="footer-links" class="span12 centertext">
-                    Copyright &copy; 2015 RockStor, Inc.&nbsp;
+                    Copyright &copy; 2015-2023 RockStor, Inc.&nbsp;
                     <a rel="license"
                        href="https://creativecommons.org/licenses/by-sa/4.0/"><img
                         alt="Creative Commons Licence" style="border-width:0"


### PR DESCRIPTION
Fixes #431.

### This pull request's proposal
Changes to be committed:
	modified:   themes/rockstor/layout.html
- adjust copyright message year to range including 2023.
- interim fix until a parametric solution can be implemented for the current year figure.

### Checklist
- [X] With the proposed changes no Sphinx errors or warnings are generated.
- [X] I have added my name to the AUTHORS file, if required (descending alphabetical order).