### PR TITLE
Refactor Rock-on contribution from repository to Rockstor Documentation

### DIFF
--- a/contribute/contribute_rockons.rst
+++ b/contribute/contribute_rockons.rst
@@ -6,37 +6,76 @@ Contributing a Rock-on
 Rock-ons are Docker plugins (see :ref:`rockons_intro` for more information)
 defined by a JSON file stored in the **rockon-registry** repository on
 `github.com <https://github.com/rockstor/rockon-registry>`_.
-As detailed in the :ref:`adding_rockons` section,
-please refer to the rockon-registry `README.md
-<https://github.com/rockstor/rockon-registry/blob/master/README.md>`_ for full
-instructions and examples on how to write your own Rock-on definition file.
 
-If you are interested in contributing a Rock-on to enable your chosen project
-on Rockstor, please submit a pull-request to the `rockon-registry
-<https://github.com/rockstor/rockon-registry>`_. Steps for doing so are similar
-to those required for :ref:`contributetorockstor` or :ref:`contributedocs`. If
-you are familiar with git, then working on an issue branch in a local clone of
-your GitHub fork is favoured. If you are not then the following is a quick and
-easy method but far less flexible.
+.. _addmyownrockon:
 
-A GitHub account is required.
+How can I add my own Rock-on?
+-----------------------------
 
-1. Create a *New issue* (button) in the **rockon-registry** `issues section
-   <https://github.com/rockstor/rockon-registry/issues>`_ and explain what you
-   are proposing.
-2. Creating your own *Fork* (button) of the `rockon-registry
-   <https://github.com/rockstor/rockon-registry>`_ (GitHub login required).
-3. Write and test your Rock-on JSON definition file following the `README.md
-   <https://github.com/rockstor/rockon-registry/blob/master/README.md>`_.
-4. In your forked copy on GitHub select **create new file** (button) and paste
-   your JSON file and name it (no spaces).
-5. Before **Commit new file** (button), ensure **"Create a new branch for this
-   commit and start a pull request..."** is selected.
-6. After the selection in 5. change the suggested branch name to e.g. **"#1234
-   Add project Y as Rock-on"** where the number is that of your issue.
+As already detailed in the :ref:`adding_rockons` section, if you are familiar
+with Docker and know how to run apps by hand, you can create a Rock-on for
+the same with a little bit of craft. There are three broad steps:
 
-You are then ready to **Propose new file** (button). Please then read and edit,
-the presented pull request appropriately; you can always edit it later.
+1. Configure the Rock-on service on your Rockstor system. Follow the steps
+described here :ref:`rockons_intro`.
+
+2. Create your Rock-on profile file, [app].json following the clues on
+the Rock-on structure described in the Rock-on repository
+`readme.md <https://github.com/rockstor/rockon-registry/blob/master/README.md>`_.
+
+3. Upload the file to ``/opt/rockstor/rockons-metastore/[app].json``. Hit
+update in the Web-UI and install your brand new Rock-on!
+
+If you like to share your app with rest of the Rockstor community, open
+an issue describing what you are trying to contribute and then a subsequently
+linked pull request in this repository.
+Please follow these guidelines when opening a pull request:
+
+1. One Rock-on per pull request please. If you are working on multiple apps,
+separate them out. It will make testing and merging a lot more manageable.
+
+2. Add a comment to your pull request detailing how you've tested it out.
+Link to the previously created issue. The more details the better as it will
+help ensure quality and benefit the whole community!
+
+3. We are trying to offer Rock-ons that are based on a multi-architecture
+docker image, i.e., it is available for :code:`amd64` (Intel/AMD CPUs) and
+:code:`arm64` (ARM-based) devices. While that might not always be possible,
+depending on the app or service which you are interested in, please keep
+that in mind and see whether you can select a docker image that has a
+multi-architecture manifest. When submitting, please add the supported
+architectures to the end of the Rockon description using the
+:code:`<p>` and :code:`</p>` tags (take a look at the descriptions of some
+of the more recent Rock-on submissions).
+
+
+.. _addvsupdrockon:
+
+Adding vs. updating a Rock-on
+-----------------------------
+
+While there are no hard and fast rules, you can follow these guidelines to
+decide whether it is better to update an existing Rock-on or submit a new one
+that contains substantial changes:
+
+1. If no Rock-on exists for your app already, create a new one. The obvious
+choice.
+
+2. Create a new Rock-on if one already exists for this project, but the new
+one will use a different docker image. E.g., an existing Rock-on uses an
+image from linuxserver.io, while the one you are interested in submitting
+uses an image created by the owner of the project. You can subsequently
+submit a proposal to deprecate the existing Rock-on. Reasons for that could
+be that the underlying docker container has not been maintained in a long
+time, or the new Rock-on will have the same or more functionality and is
+more popular with the community.
+
+3. Update the existing Rock-on if the changes do not include the use of a
+different image. E.g., the Handbrake Rock-on was expanded with a few useful
+user parameters over time, but continued to use the same underlying docker
+image. Here it made more sense to update the existing Rock-on instead of
+submitting a new version.
+
 
 Which Docker image should I use?
 --------------------------------
@@ -63,6 +102,98 @@ guidelines can help:
   user intervention at the command line before and/or after.
 * Finally, the image size is another helpful factor, with smaller images being
   usually favored.
+
+Environment setup
+-----------------
+
+Go to the `rockon-registry repo <https://github.com/rockstor/rockon-registry>`_
+and click on the <b>Fork</b> button. This will fork the repository into your
+profile which serves as your private git remote called origin. The next few
+git steps are demonstrated on a Linux terminal.
+
+Create a local clone of your fork.
+
+.. code-block:: console
+
+    git clone git@github.com:your_github_username/rockon-registry.git
+
+Configure this new git repo with your name and email address. This is
+required to accurately record collaboration.
+
+.. code-block:: console
+
+    cd rockon-registry
+    git config user.name "Firstname Lastname"
+    git config user.email your_email_address
+
+Add a remote called upstream to periodically rebase your local repository
+with changes in the upstream made by other contributors.
+
+.. code-block:: console
+
+    git remote add upstream https://github.com/rockstor/rockon-registry.git
+
+The above 4 steps help you setup your local environment. If you are familiar
+with git and use an IDE like Eclipse, you can achieve the same outcome in a
+different way. Here, we listed the simple terminal way of setting it up.
+
+Steps to Contribute a Rock-on with a Pull Request
+-------------------------------------------------
+
+Rebase your master branch before making your own changes.
+
+.. code-block:: console
+
+    cd rockon-registry
+    git checkout master
+    git pull --rebase upstream master
+
+Checkout a new/separate branch for your Rock-on
+
+.. code-block:: console
+
+   git checkout -b rockon_name
+
+Add and commit your Rock-on to git. Say you are updating the
+**Syncthing** Rock-on and have the :code:`syncthing.json` tested
+and ready to go. First copy the file over to your repo. Next,
+
+.. code-block:: console
+
+    git add syncthing.json
+    git commit -m 'update syncthing rock-on'
+
+When adding a new Rock-on, e.g. based on the fictious **moonshine**
+docker image and created the new file :code:`moonshine.json`, also
+add the name of this file (case-sensitive) to the :code:`root.json`
+file (it's alphabetically sorted). This means you add both files to
+the commit,
+
+.. code-block:: console
+
+    git add moonshine.json root.json
+    git commit -m 'add moonshine rock-on`
+
+Now you can push your Rock-on to github. :code:`<branch_name>` is from
+above where you checked out a new branch.
+
+.. note::
+
+   When updating to a new version (as mentioned in scenario 2 in the
+   :ref:`addvsupdrockon` section, first submit a pull request adding
+   the new Rock-On (you will have to use a slightly different name).
+   Then follow the :ref:`deleterockons` process. This way, the history
+   more clearly represents what transpired with this Rock-on.
+
+.. code-block:: console
+
+    git push origin <branch_name>
+
+Now you can go to github, open an issue on the rockstor repo if you have
+not done so already that describes the Rock-on that you were working on
+and then open a pull request from your forked repo, populate it with the
+requested info (e.g., link it to a previously opened issue) and
+submit it.
 
 .. _deleterockons:
 

--- a/contribute/contribute_rockons.rst
+++ b/contribute/contribute_rockons.rst
@@ -107,7 +107,7 @@ Environment setup
 -----------------
 
 Go to the `rockon-registry repo <https://github.com/rockstor/rockon-registry>`_
-and click on the <b>Fork</b> button. This will fork the repository into your
+and click on the **Fork** button. This will fork the repository into your
 profile which serves as your private git remote called origin. The next few
 git steps are demonstrated on a Linux terminal.
 

--- a/contribute/contribute_rockons.rst
+++ b/contribute/contribute_rockons.rst
@@ -134,7 +134,7 @@ with changes in the upstream made by other contributors.
     git remote add upstream https://github.com/rockstor/rockon-registry.git
 
 The above 4 steps help you setup your local environment. If you are familiar
-with git and use an IDE like Eclipse, you can achieve the same outcome in a
+with git and use an IDE, you can achieve the same outcome in a
 different way. Here, we listed the simple terminal way of setting it up.
 
 Steps to Contribute a Rock-on with a Pull Request

--- a/contribute/contribute_rockons.rst
+++ b/contribute/contribute_rockons.rst
@@ -26,7 +26,7 @@ the Rock-on structure described in the Rock-on repository
 3. Upload the file to ``/opt/rockstor/rockons-metastore/[app].json``. Hit
 update in the Web-UI and install your brand new Rock-on!
 
-If you like to share your app with rest of the Rockstor community, open
+If you would like to share your app with the rest of the Rockstor community, open
 an issue describing what you are trying to contribute and then a subsequently
 linked pull request in this repository.
 Please follow these guidelines when opening a pull request:

--- a/contribute/contribute_rockons.rst
+++ b/contribute/contribute_rockons.rst
@@ -108,7 +108,7 @@ Environment setup
 
 Go to the `rockon-registry repo <https://github.com/rockstor/rockon-registry>`_
 and click on the **Fork** button. This will fork the repository into your
-profile which serves as your private git remote called origin. The next few
+profile which serves as your personal git remote called origin. The next few
 git steps are demonstrated on a Linux terminal.
 
 Create a local clone of your fork.

--- a/interface/overview.rst
+++ b/interface/overview.rst
@@ -203,7 +203,7 @@ instructions they are like all Rock-on installs, fairly self explanatory.
 * `Ombi <https://ombi.io/>`_: Host your own Plex Request and user management system
 * `OwnCloud-Official <https://owncloud.com/>`_: Secure file sharing and hosting
 * `Pi-hole <https://pi-hole.net/>`_: A black hole for Internet advertisements
-* `PocketMine <https://www.pocketmine.net/>`_: Server software for Minecraft: Pocket Edition
+* `PocketMine <https://pmmp.io/>`_: Server software for Minecraft: Pocket Edition
 * `Radarr <https://github.com/Radarr/Radarr>`_: Radarr is a PVR for Movies on Usenet and Torrents
 * `Resilio Synch <https://www.resilio.com/>`_: Fast, private file sharing for teams and individuals
 * `Rocket.Chat <https://rocket.chat/>`_: Open Source Chat Platform

--- a/interface/overview.rst
+++ b/interface/overview.rst
@@ -3,21 +3,26 @@
 Rock-ons (Docker Plugins)
 =========================
 
-**Rock-ons** are Rockstor's name for it's use of `docker
-<https://www.docker.com/>`_ containers to provide a **Plugin System** to easily
-expand the functions of a base Rockstor install. This feature is relatively new
-to Rockstor but is proving to be quite popular and is under active development.
+**Rock-ons** are Rockstor's name for its use of `docker
+<https://www.docker.com/>`_ containers to provide a **Plugin System** to
+easily expand the functions of a base Rockstor install.
 
 Each Rock-on aims to provide a single additional service and the list of
 :ref:`rockons_available` is expanding all the time.
+
+.. note::
+    We are striving to provide Rock-ons as multi-architecture apps,
+    namely for :code:`amd64` (Intel/AMD CPUs) and :code:`arm64` (ARM-based) devices.
+    This is not always possible, however the supported architectures are
+    usually noted in the Rock-on description in the WebUI.
 
 .. _rockons_preinstall:
 
 Initial Rock-ons Setup
 ----------------------
 
-As Rock-ons / docker containers are like mini linux installs they require
-somewhere to live.  In Rockstor it is recommended that you setup a Share
+As Rock-ons/docker containers are like mini linux installs, they require
+somewhere to live. In Rockstor it is recommended that you setup a Share
 specifically for this purpose.
 
 .. warning::
@@ -25,12 +30,14 @@ specifically for this purpose.
     configurations on. Storing Rock-ons on the system disk will make Rock-on
     restores more difficult. See :ref:`rockonrestore` for more information.
 
-Note that all Rock-ons will then be installed into this shared area but each
-will remain independent and during the setup of each Rock-on you are given the
-option to store their respective configuration and data in other shares. This
-is good practice as it keeps your Rock-on config and data apart from the
-Rock-ons themselves. You do not have to separate the config and data within
-each rock-on but that is also good practice, and is why this option is offered.
+.. note::
+    All Rock-ons will then be installed into this shared area but each
+    will remain independent and during the setup of each Rock-on you are given
+    the option to store their respective configuration and data in other shares.
+    This is good practice as it keeps your Rock-on config and data apart from
+    the Rock-ons themselves. You do not have to separate the config and data
+    within each rock-on but that is also good practice, and is why this option
+    is offered.
 
 It is assumed you have already setup your :ref:`pools` and one or more
 shares in those pools (see our :ref:`createshare`) appropriate for your
@@ -127,24 +134,26 @@ the current list of freely available rock-on definition files and servers
 as the repository for :ref:`rockons_available`. Please consider contributing,
 or asking your favourite project to contribute, a rock-on via a GitHub pull
 request to this repository (see :ref:`contributerockons` for more
-information). Note that it is also possible to add to the available Rock-ons
-by placing a suitably configured and named json file in the
-*/opt/rockstor/rockons-metastore* directory of your Rockstor install. For full
-instructions and examples please see the rockon-registry
-`README.md <https://github.com/rockstor/rockon-registry/blob/master/README.md>`_.
-Some projects prefer to host their own Rock-on plugins and this feature enables
-the use of other projects official Rock-ons. An example of a project that takes
-advantage of this feature is `Emby <https://emby.media>`_ with their official
-`Rock-on <https://github.com/MediaBrowser/Emby.Build/blob/master/rockstor-plugins/embyserver.json>`_
-definition file for the Emby server component. However this same Emby Rock-on
-has now been added to the official Rockstor Rock-on registry.
+information).
+
+.. note::
+    It is also possible to add to the available Rock-ons by placing a suitably
+    configured and named json file in the :code:`/opt/rockstor/rockons-metastore`
+    directory of your Rockstor install. For full instructions and examples
+    please see the :ref:`addmyownrockon` section. Some projects prefer to host
+    their own Rock-on plugins and this feature enables the use of other projects'
+    official Rock-ons. An example of a project that takes advantage of this
+    feature is `Emby <https://emby.media>`_ with their official `Rock-on
+    <https://github.com/MediaBrowser/Emby.Build/blob/master/rockstor-plugins/embyserver.json>`_
+    definition file for the Emby server component. However this same Emby
+    Rock-on has now been added to the official Rockstor Rock-on registry.
 
 .. _rockons_available:
 
 Rock-ons available by default
 -----------------------------
 
-As this list is continually growing the best place to view the currently
+As this list is continually growing, the best place to view the currently
 included by default Rock-ons is at the
 `rockon-registry <https://github.com/rockstor/rockon-registry>`_ or on the
 Rock-ons page *All* tab within the Rockstor WebUI directly after pressing the
@@ -158,7 +167,6 @@ Rock-ons without write-ups
 Although the following Rock-ons are currently without specific install
 instructions they are like all Rock-on installs, fairly self explanatory.
 
-* `Bitcoin <https://bitcoin.com/>`_: Bitcoin full node
 * `Booksonic <https://booksonic.org>`_: Audiobooks streaming server
 * `Cardigann <https://github.com/cardigann/cardigann>`_: A proxy server for adding new indexers to Sonarr and other media managers
 * `Collabora online <https://www.collaboraoffice.com/code/>`_: LibreOffice-based online office suite


### PR DESCRIPTION
Fixes #451.

### This pull request's proposal
 Changes to be committed:
	modified:   contribute/contribute_rockons.rst
	modified:   interface/overview.rst
- refactor, move and include contribution instructions from Rock-on repository into Rockstor documentation.
- Minor spelling/formulation corrections in both files

### Checklist
- [X] With the proposed changes no Sphinx errors or warnings are generated.
- [X] I have added my name to the AUTHORS file, if required (descending alphabetical order).