### PR TITLE
Replace Manpage links (Issue #453)

### DIFF
--- a/interface/storage/file_sharing/nfs_ops.rst
+++ b/interface/storage/file_sharing/nfs_ops.rst
@@ -44,10 +44,10 @@ a new NFS export.
 Various fields of the form are explained as follows.
 
 * **Shares to export**: Choose one or more shares to be exported.
-* **NFS Clients** or **Host String**: This field can be a single host, comma separated host names, hostnames with wildcards or IP networks. This field can be complex. For a detailed explanation, read the `manpage <https://linux.die.net/man/5/exports>`_ of exports.
+* **NFS Clients** or **Host String**: This field can be a single host, comma separated host names, hostnames with wildcards or IP networks. This field can be complex. For a detailed explanation, read the `manpage <https://manpages.opensuse.org/Tumbleweed/nfs-kernel-server/exports.5.en.html>`_ of exports.
 * **Writable**: Choose ro to make the share(s) available read-only or rw for read-write.
 * **Sync**: Sync (synchronous) mode is the default and the norm. For asynchronous IO, select
-  async. See the `manpage <https://linux.die.net/man/5/exports>`_ of exports for more information.
+  async. See the `manpage <https://manpages.opensuse.org/Tumbleweed/nfs-kernel-server/exports.5.en.html>`_ of exports for more information.
 
 .. _edit_nfs_export:
 
@@ -154,7 +154,7 @@ you can manually edit your :code:`/etc/fstab` file to contain the following line
 .. note::
 
     The above can take many important options to control the behavior of this NFS mount.
-    See the `nfs mount manpage <https://linux.die.net/man/5/nfs>`_ for further details.
+    See the `nfs mount manpage <https://manpages.opensuse.org/Tumbleweed/nfs-client/nfs.5.en.html>`_ for further details.
 
 .. _accessshares_nfs_macos:
 

--- a/interface/system/services.rst
+++ b/interface/system/services.rst
@@ -5,7 +5,7 @@ Services
 
 Rockstor supports many services that are necessary or useful in a storage
 system. Service management, *i.e.* turning on or off, and configuration can be
-done via the **System** - **Services** page of the web-UI. Note that the
+done via the **System** - **Services** page of the Web-UI. Note that the
 **spanner icon** next to each service name is used to **configure** that
 service.
 
@@ -131,19 +131,19 @@ The individual fields of the form are described below.
 
 * **Domain/Realm name**: Specifies the desired Active Directory or Domain.
 * **Administrator Username**:  Name of the user to use for the enrollment to
-  the AD. Tihs should be the AD's administrator account.
+  the AD. This should be the AD's administrator account.
 * **Password**: Password for the Administrator username.
 * **Enable enumeration**: Fetch and display all users/groups values. As this
   option can have a notable performance cost in some servers (with high number
   of users, for instance), this option is disabled by default. Note, however,
   that this option must be enabled for Rockstor to be able to list AD users and
-  groups in the web-UI. See `SSSD FAQ <https://docs.pagure.org/sssd.sssd/users/faq.html#when-should-i-enable-enumeration-in-sssd-or-why-is-enumeration-disabled-by-default>`_ for
+  groups in the Web-UI. See `SSSD FAQ <https://docs.pagure.org/sssd.sssd/users/faq.html#when-should-i-enable-enumeration-in-sssd-or-why-is-enumeration-disabled-by-default>`_ for
   further details.
 * **Disable automatic ID mapping**: By default, the AD provider will map UID
   and GID values from the objectSID parameter in Active Directory. Check this
   option if you want to disable ID mapping and instead rely on POSIX attributes
-  defined in Active Directory. See `SSSD documentation <https://linux.die.net/man/5/sssd-ad>`_ for
-  furhter details.
+  defined in Active Directory. See `SSSD documentation <https://manpages.opensuse.org/Tumbleweed/sssd-ad/sssd-ad.5.en.html>`_ for
+  further details.
 * **Treat user and group names as case-sensitive**
 
 Rockstor 4 relies on `SSSD <https://sssd.io/>`_ for the management of identities
@@ -153,7 +153,7 @@ further customize the enrollment into an AD.
 Upon submission of the AD configuration form, Rockstor will test the
 configuration settings by attempting to *discover* the AD domain and save the
 configuration if successful. If Rockstor cannot discover the AD domain, it will
-report the error back to the web-UI; notably, verify that the AD domain can be
+report the error back to the Web-UI; notably, verify that the AD domain can be
 resolved by name via DNS (see `Red Hat Windows Integration Guide <https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/7/html/windows_integration_guide/sssd-integration-intro#sssd-ad-proc>`_ for
 further documentation).
 
@@ -191,7 +191,7 @@ further customize the connection to the LDAP server.
 .. note::
   The LDAP implementation is an area under active development. As a result, we
   are seeking feedback from users on further customizations and settings to
-  implement in Rockstor web-UI. Please visit our `friendly forum <https://forum.rockstor.com>`_
+  implement in Rockstor Web-UI. Please visit our `friendly forum <https://forum.rockstor.com>`_
   to share your feedback or provide input on further LDAP expansion.
 
 Note that a successful configuration of the LDAP service does not connect the
@@ -205,7 +205,7 @@ Network Information Server (NIS)
 
 NIS is a directory service to connect to a NIS server.
 
-In the web-ui, click on *System* tab to go to the *System* view. This also
+In the Web-UI, click on *System* tab to go to the *System* view. This also
 serves as the *Services* view, which is selected by default in the left
 sidebar. To configure NIS, click on the **wrench** icon and submit the form
 with appropriate values as shown below.
@@ -221,14 +221,12 @@ NUT-UPS
 -------
 
 A (currently Beta) `Network UPS Tools <https://networkupstools.org/>`_
-based service to orchestrate gracefull system shutdown in the event of a power
+based service to orchestrate graceful system shutdown in the event of a power
 outage. Please see our: :ref:`ups_setup` section for more details.
 
 Rock-Ons (Docker plugin system)
 -------------------------------
-
-This is a very new service that is still in Beta, please see :ref:`rockons_intro`
-for an introduction to Rockstor's `Docker <https://www.docker.com/>`_ based
-plugin system.
+Please see :ref:`rockons_intro` for an introduction to Rockstor's
+`Docker <https://www.docker.com/>`_ based plugin system.
 
 **To start or stop any service, click the corresponding ON or OFF button**


### PR DESCRIPTION
Fixes #453.

### This pull request's proposal
Changes to be committed:
	modified:   interface/storage/file_sharing/nfs_ops.rst
	modified:   interface/system/services.rst
- replace manpage links with opensuse sourced ones
- some cosmetic cleanup

### Checklist
- [X] With the proposed changes no Sphinx errors or warnings are generated.
- [X] I have added my name to the AUTHORS file, if required (descending alphabetical order).