### PR TITLE
Distribution update from 15.5 to 15.6 - howto #476

### DIFF
--- a/howtos.rst
+++ b/howtos.rst
@@ -9,6 +9,7 @@ How-tos & Guides
    howtos/15-2_to_15-3
    howtos/15-3_to_15-4
    howtos/15-4_to_15-5
+   howtos/15-5_to_15-6
    howtos/rpm_install
    howtos/v3_to_v4
    howtos/reinstall

--- a/howtos/15-2_to_15-3.rst
+++ b/howtos/15-2_to_15-3.rst
@@ -4,7 +4,7 @@ Distribution update from 15.2 to 15.3
 =====================================
 
 Rockstor version 4 has been released in the testing channel for the entire life of openSUSE Leap 15.2.
-As such there are many installs "Build on openSUSE" Leap 15.2 - End of Life (EOL) December 2021.
+As such there are many installs "Built on openSUSE" Leap 15.2 - End of Life (EOL) December 2021.
 This How-to includes instruction on moving an existing 15.2 based install over, **in-place** to the new openSUSE Leap 15.3 base.
 
 .. note::

--- a/howtos/15-3_to_15-4.rst
+++ b/howtos/15-3_to_15-4.rst
@@ -4,7 +4,7 @@ Distribution update from 15.3 to 15.4
 =====================================
 
 Rockstor version 4 has been released in the testing channel for the entire life of openSUSE Leap 15.3.
-As such there are many installs "Build on openSUSE" Leap 15.3 - **End of Life (EOL) December 2022**.
+As such there are many installs "Built on openSUSE" Leap 15.3 - **End of Life (EOL) December 2022**.
 This How-to includes instruction on moving an existing 15.3 based install over, **in-place**,
 to the newer "Build on openSUSE" Leap 15.4.
 

--- a/howtos/15-4_to_15-5.rst
+++ b/howtos/15-4_to_15-5.rst
@@ -3,7 +3,7 @@
 Distribution update from 15.4 to 15.5
 =====================================
 
-Rockstor installs "Build on openSUSE" Leap 15.4 - **End of Life (EOL) December 2023** - should be *distribution updated*.
+Rockstor installs "Built on openSUSE" Leap 15.4 - **End of Life (EOL) December 2023** - should be *distribution updated*.
 This How-to includes instruction on moving an existing 15.4 based install over, **in-place**,
 to the next major version of our base OS.
 Only one major version jump must be attempted at any one time.

--- a/howtos/15-5_to_15-6.rst
+++ b/howtos/15-5_to_15-6.rst
@@ -1,0 +1,175 @@
+.. _155_to_156:
+
+Distribution update from 15.5 to 15.6
+=====================================
+
+Rockstor installs "Built on openSUSE" Leap 15.5 - **End of Life (EOL) December 2024** - can be *distribution updated*.
+This How-to includes instruction on moving an existing 15.5 based install over, **in-place**,
+to the next major version of our base OS.
+Only one major version jump must be attempted at any one time.
+If your Rockstor install is not based on 15.5, consider one of our other "Distribution update ..." How-tos.
+
+- **A minimum Rockstor version of 5.0.9-0 is recommended before attempting this OS update.**
+
+.. note::
+
+    There are always less unknowns for fresh installs.
+    It is advisable to consider a fresh-start via the latest **Recommended** Rockstor installer.
+    See `Downloads <https://rockstor.com/dls.html>`_ for the available options.
+    See also our :ref:`installer_howto`.
+
+    Existing :ref:`pools` and :ref:`config_backup` files remain compatible and importable.
+
+.. warning::
+
+    For both **in-place** and **re-install/import** approaches; always ensure all backups are refreshed.
+    For re-install/import all data on a re-used system disk ('ROOT' Pool) will be irreversibly destroyed.
+    Alternatively use a fresh system disk to provide a fail over of reverting to the original system disk.
+    Do not attach both old and new system disks simultaneously.
+    Only one Rockstor system disk must be attached at any one time.
+
+Before attempting an **in-place** distribution update, be sure that you have applied all regular updates first.
+The :ref:`updating_rockstor` section covers how to do this either via the Web-UI or via the command line.
+
+.. _155_156-overview:
+
+Overview
+--------
+
+This **Distribution Update** procedure is well established in our upstream base OS of openSUSE Leap.
+Below we detail the following steps, each in their own sections:
+
+- Update repositories
+- Distribution update
+- Reporting issues
+
+See our FAQ entry :ref:`faq_rockstor4_repos` for more context.
+
+.. _155_156-update_repos:
+
+Update repositories
+-------------------
+
+Here we stream edit/replace all :code:`15.5` and :code:`15_5` instances with :code:`15.6` and :code:`15_6` respectively via:
+
+.. code-block:: console
+
+    sed -i 's/15_5/15_6/g' /etc/zypp/repos.d/*.repo
+    sed -i 's/15\.5/15\.6/g' /etc/zypp/repos.d/*.repo
+
+.. note::
+
+    This does not change the repository configuration file names themselves.
+    This is not important and can serve as an indicator of a system's history/origin.
+    The filenames for these repositories are cosmetic only.
+
+.. _155_156-distro-update:
+
+Distribution update
+-------------------
+
+**Double check all repositories are as-expected.**
+The following command should output a very similar list of repositories to those indicated.
+:ref:`Rockstor-Testing <testing_channel>` may be replaced by :ref:`Rockstor-Stable <stable_channel>`, or neither may be present;
+depending on your :ref:`update channel selection <update_channels>`
+
+.. code-block:: console
+
+    zypper --releasever=15.6 lr -U
+
+    Warning: Enforced setting: $releasever=15.6
+    Repository priorities in effect:                                                                (See 'zypper lr -P' for details)
+          97 (raised priority)  :  1 repository
+          99 (default priority) :  6 repositories
+         105 (lowered priority) :  1 repository
+
+    #  | Alias                              | Name                                                                                        | Enabled | GPG Check | Refresh | URI
+    ---+------------------------------------+---------------------------------------------------------------------------------------------+---------+-----------+---------+----------------------------------------------------------------------------------------
+     8 | repo-openh264                      | repo-openh264                                                                               | Yes     | (r ) Yes  | Yes     | http://codecs.opensuse.org/openh264/openSUSE_Leap
+     9 | repo-sle-debug-update              | Update repository with debuginfo for updates from SUSE Linux Enterprise 15                  | No      | ----      | ----    | http://download.opensuse.org/debug/update/leap/15.6/sle/
+     1 | Leap_15_6                          | Leap_15_6                                                                                   | Yes     | ( p) Yes  | Yes     | http://download.opensuse.org/distribution/leap/15.6/repo/oss/
+     7 | repo-backports-update              | Update repository of openSUSE Backports                                                     | Yes     | (r ) Yes  | Yes     | http://download.opensuse.org/update/leap/15.6/backports/
+     6 | repo-backports-debug-update        | Update repository with updates for openSUSE Leap debuginfo packages from openSUSE Backports | No      | ----      | ----    | http://download.opensuse.org/update/leap/15.6/backports_debug/
+    10 | repo-sle-update                    | Update repository with updates from SUSE Linux Enterprise 15                                | Yes     | (r ) Yes  | Yes     | http://download.opensuse.org/update/leap/15.6/sle/
+     3 | Rockstor-Testing                   | Rockstor-Testing                                                                            | Yes     | (r ) Yes  | Yes     | http://updates.rockstor.com:8999/rockstor-testing/leap/15.6
+     4 | home_rockstor                      | home_rockstor                                                                               | Yes     | (r ) Yes  | Yes     | https://download.opensuse.org/repositories/home:/rockstor/15.6/
+     5 | home_rockstor_branches_Base_System | home_rockstor_branches_Base_System                                                          | Yes     | (r ) Yes  | Yes     | https://download.opensuse.org/repositories/home:/rockstor:/branches:/Base:/System/15.6/
+     2 | Leap_15_6_Updates                  | Leap_15_6_Updates                                                                           | Yes     | ( p) Yes  | Yes     | https://download.opensuse.org/update/leap/15.6/oss/
+
+Before the big **Distribution Update**
+we must import all the new repository keys and information from all of the changes made above.
+
+.. code-block:: console
+
+    zypper --releasever=15.6 --non-interactive --gpg-auto-import-keys refresh
+
+And finally the actual base OS update itself.
+Here we instruct zypper to download all packages first.
+This helps to avoid a download failure part-way through this rather sensitive process.
+
+The download size plus the extra disk space required will be around 600 MiB.
+So ensure that you have at least 2 GB free on your system disk ('ROOT' Pool), before proceeding.
+
+.. note::
+
+    N.B. in the following step we are changing the legs upon which the entire system is running,
+    it is best to have the system under as minimal load as possible.
+    As such it is advisable to close any Rockstor Web-UI browser tabs during this process.
+
+.. warning::
+
+    It is imperative that the system is not rebooted during this process.
+    It is also important to reboot the system after the following
+    "zypper ... dup ..." command has completed.
+    This enables the new legs to be the ones running the show.
+    **Upstream reference**:
+    `SDB:System upgrade <https://en.opensuse.org/SDB:System_upgrade>`_
+
+.. code-block:: console
+
+    zypper --releasever=15.6 dup --download-in-advance --allow-vendor-change --no-recommends
+
+This document was create prior to the final public release of openSUSE Leap 15.6.
+At the time the following was experienced:
+
+.. code-block:: console
+
+    Problem: 1: the to be installed libopenssl-1_1-devel-1.1.1w-150600.3.10.x86_64 conflicts with 'libopenssl-devel > 1.1.1w' provided by the to be installed libopenssl-devel-3.1.4-150600.2.1.noarch
+     Solution 1: Following actions will be done:
+      keep obsolete libopenssl-1_1-devel-1.1.1l-150500.17.28.2.x86_64
+      keep obsolete libopenssl-devel-1.1.1l-150400.1.5.noarch
+      keep obsolete openssl-1.1.1l-150400.1.5.noarch
+      keep obsolete openssl-1_1-1.1.1l-150500.17.28.2.x86_64
+     Solution 2: deinstallation of libopenssl-1_1-devel-1.1.1l-150500.17.28.2.x86_64
+     Solution 3: deinstallation of libopenssl-devel-1.1.1l-150400.1.5.noarch
+
+    Choose from above solutions by number or cancel [1/2/3/c/d/?] (c):
+
+If you see the above message: it is currently advised to choose **Solution 2**.
+
+We use --allow-vendor-change as some prior openSUSE packages are now supplied directly from SuSE.
+The --no-recommends is to keep to our JeOS (Just enough Operating System) `minimal` origin.
+I.e. don't install things like manuals etc and other 'extra' packages.
+
+
+
+To reboot from the command line once the above "zypper ... dup ..." command has finished,
+enter the following commands as root:
+
+.. code-block::
+
+    sync
+    reboot
+
+.. _155_156-report:
+
+Reporting issues
+----------------
+
+As always we welcome feedback to improve what we do.
+So please consider reporting your experience or suggestions on our friendly
+`Community Forum <https://forum.rockstor.com/>`_.
+
+A distribution update is in many ways more complex than an entirely fresh install.
+And given Rockstor's overall size a re-install can be very quick.
+But if you have a complex install an in-place distribution update can be the way to go.

--- a/themes/rockstor/layout.html
+++ b/themes/rockstor/layout.html
@@ -115,7 +115,7 @@
         <div id="footer">
             <div class="row-fluid">
                 <div id="footer-links" class="span12 centertext">
-                    Copyright &copy; 2015-2023 RockStor, Inc.&nbsp;
+                    Copyright &copy; 2024 The Rockstor Project.&nbsp;
                     <a rel="license"
                        href="https://creativecommons.org/licenses/by-sa/4.0/"><img
                         alt="Creative Commons Licence" style="border-width:0"


### PR DESCRIPTION
Contextually modified from our prior 15.4 to 15.5 howto. Some re-ordering of notes/warnings re zypper dup.

Includes
- Build/Built typo fix in all our 'Distribution update ...' howtos.
- Update docs copyright to be in line with website.

Fixes #476

### Checklist
- [x] With the proposed changes no Sphinx errors or warnings are generated.
- [x] I have added my name to the AUTHORS file, if required (descending alphabetical order).