### PR TITLE
Update "Install on Vanilla openSUSE/SuSE SLES" re OS versioning #463

### DIFF
--- a/howtos/rpm_install.rst
+++ b/howtos/rpm_install.rst
@@ -3,26 +3,34 @@
 Install on Vanilla openSUSE/SuSE SLES
 =====================================
 
-Our installer profiles (`<https://github.com/rockstor/rockstor-installer>`_), and consequently our pre-built installers, deviate only a little from openSUSE’s JeOS appliance profiles.
-As a result, it is possible to manually configure a Vanilla openSUSE/SuSE SLES based install to then install Rockstor's rpm.
+Our installer profiles (`<https://github.com/rockstor/rockstor-installer>`_),
+and consequently our pre-built installers,
+deviate only a little from openSUSE’s JeOS / Minimal appliance profiles.
+As a result,
+one can manually configure a Vanilla openSUSE/SuSE SLES install to be the host OS to a `rockstor` rpm customisation.
 
 .. warning::
 
     **For advanced users only**
 
     This install method is predominantly for developers or advanced users and will likely require additional maintenance.
-    It may also serve as an option where a SLES base is required. Please note our undesirable disabling of apparmor.
-    We hope to resolve this partial failure in due time.
+    It may also serve as an option where a SLES base is required.
+    Please note our undesirable disabling of apparmor,
+    we hope to resolve this shortfall in due time.
+    Pull requests welcome.
 
-The procedure, not recommended or supported, consists in adding the relevant Rockstor repositories to a dedicated vanilla openSUSE / SuSE SLES non transactional server install.
-The base OS version is assumed to be already found within our Rockstor 4 `Installer Recipes <https://github.com/rockstor/rockstor-installer>`_, and in the case of SLES, to be at least version 15.4--when the upstream binary compatibility between openSUSE Leap & SuSE SLES matured.
+This procedure, not recommended or supported,
+constitutes adding the relevant Rockstor repositories to a dedicated vanilla openSUSE / SuSE SLES non transactional server install.
+The base OS version is assumed to be within our current profiles at:
+`Installer Recipes <https://github.com/rockstor/rockstor-installer>`_.
+For recommended openSUSE versions of the host OS, see our `downloads page <https://rockstor.com/dls.html>`_.
 
 .. _rpm_install_procedure:
 
 Procedure
 ---------
 
-The relevant commands (assuming a 15.4 base version) are as follows:
+The relevant commands are as follows:
 
 First, disable :code:`apparmor`.
 
@@ -36,24 +44,34 @@ Then, ensure :code:`NetworkManager` is installed and running.
 
     zypper install --no-recommends NetworkManager
     systemctl disable wicked
-    systemctl enable NetworkManager
-    systemctl start NetworkManager
+    systemctl enable --now NetworkManager
 
-Define and instantiate the rpm repositories required by Rockstor (all are multiarch).
+Instantiate the package repositories required by Rockstor (all are multi-arch).
+
+.. note::
+
+    In the following replace all `15.X` instances to match your installed OS version.
 
 .. code-block:: console
 
-    zypper --non-interactive addrepo --refresh -p105 https://download.opensuse.org/repositories/home:/rockstor/15.4/ home_rockstor
-    zypper --non-interactive addrepo --refresh -p97 https://download.opensuse.org/repositories/home:/rockstor:/branches:/Base:/System/15.4/ home_rockstor_branches_Base_System
+    zypper --non-interactive addrepo --refresh -p105 https://download.opensuse.org/repositories/home:/rockstor/15.X/ home_rockstor
+    zypper --non-interactive addrepo --refresh -p97 https://download.opensuse.org/repositories/home:/rockstor:/branches:/Base:/System/15.X/ home_rockstor_branches_Base_System
     rpm --import https://raw.githubusercontent.com/rockstor/rockstor-core/master/conf/ROCKSTOR-GPG-KEY
-    zypper addrepo -f http://updates.rockstor.com:8999/rockstor-testing/leap/15.4/ Rockstor-Testing
+    zypper addrepo -f http://updates.rockstor.com:8999/rockstor-testing/leap/15.X/ Rockstor-Testing
     zypper --non-interactive --gpg-auto-import-keys refresh
 
-Finally, install and start Rockstor.
+Finally, install and enable/start Rockstor via it's systemd services.
+
+.. note::
+
+    In the following replace `X.X.X-X` with your preferred rockstor package version.
+    For available `rockstor` package versions see our `downloads page <https://rockstor.com/dls.html>`_.
+    The initial Stable rpm release, in each development phase, appears first at the end of the prior testing channel phase.
+    :ref:`Update channel <update_channels>` selection can be modified, if required, via the Web-UI.
 
 .. code-block:: console
 
-    zypper in --no-recommends rockstor-4.5.8-0
+    zypper in --no-recommends rockstor-X.X.X-X
     systemctl enable --now rockstor-bootstrap
 
 .. warning::
@@ -61,5 +79,5 @@ Finally, install and start Rockstor.
     Please note that Rockstor is not yet Multi-path controller compatible.
 
 .. note::
-    Please visit our `friendly forum <https://forum.rockstor.com/>`_ for questions and suggestions for improving these instructions.
+    Visit our `friendly forum <https://forum.rockstor.com/>`_ for questions and suggestions for improving these instructions.
     As always, GitHub pull requests are welcome: `<https://github.com/rockstor/rockstor-doc>`_.


### PR DESCRIPTION
Minor re-wording & Semantic Linefeed improvements - along with removing explicit OS versioning. Referending instead our downloads page re available rpms.

Adds note re first stable rpm in phase, appearing beforehand in the prior testing phase.

Fixes #463

### Checklist
- [x] With the proposed changes no Sphinx errors or warnings are generated.
- [x] I have added my name to the AUTHORS file, if required (descending alphabetical order).