### PR TITLE
Add Tailscale to list of features #461

### DIFF
--- a/index.rst
+++ b/index.rst
@@ -7,7 +7,7 @@ Welcome to Rockstor
 ===================
 
 Rockstor (:ref:`rockstor_license`) is a **Linux & BTRFS-based** Network Attached Storage **(NAS) Appliance**, with **Private Cloud** capabilities.
-**Rockstor 4 is "Built on openSUSE"** and :ref:`our_kiwi_ng_installer` is licensed according to the :ref:`installer_license`.
+**Rockstor is "Built on openSUSE"** and :ref:`our_kiwi_ng_installer` is licensed according to the :ref:`installer_license`.
 **We focus on easy-install, setup, and use.**
 
 We extend our advanced NAS features, via Docker, to host an ever growing range of easy to install apps we call :ref:`rockons_intro`.
@@ -15,7 +15,7 @@ This in turn moves us nicely into the realms of a private cloud server.
 
 See our :ref:`features_overview` section for a list of features & capabilities: available and planned.
 
-Rockstor 4 can be installed on commodity x86_64 and ARM64 hardware.
+Rockstor can be installed on commodity x86_64 and ARM64 hardware.
 AArch64 server compatibility relies on `Embedded Boot <https://github.com/ARM-software/ebbr>`_ or `Server boot <https://github.com/ARM-software/sbsa-acs>`_ standards,
 e.g. like the recently released `Ten64 <https://www.crowdsupply.com/traverse-technologies/ten64>`_ platform--the designers of which `Traverse technologies <https://traverse.com.au/>`_
 are valued contributors to our `rockstor-core <https://github.com/rockstor/rockstor-core>`_, `rockstor-installer <https://github.com/rockstor/rockstor-installer>`_, and
@@ -79,9 +79,11 @@ Some unsupported and planned features are also listed.
    +--------------------------------------------------+---------+------------------------------------------------------------+
    | SSH                                              | prod    | Standard bash shell                                        |
    +--------------------------------------------------+---------+------------------------------------------------------------+
-   | :ref:`activedirectory`                           | prod    | Rockstor v4 uses sssd                                      |
+   | `Tailscale <https://tailscale.com/>`_            | prod    | Config via :ref:`Services Tailscale <configure_tailscale>` |
    +--------------------------------------------------+---------+------------------------------------------------------------+
-   | :ref:`ldap`                                      | prod    | Rockstor v4 uses sssd                                      |
+   | :ref:`activedirectory`                           | prod    | Uses `sssd <https://sssd.io/>`_                            |
+   +--------------------------------------------------+---------+------------------------------------------------------------+
+   | :ref:`ldap`                                      | prod    | Uses `sssd <https://sssd.io/>`_                            |
    +--------------------------------------------------+---------+------------------------------------------------------------+
    | :ref:`nis`                                       | prod    | Network Information System                                 |
    +--------------------------------------------------+---------+------------------------------------------------------------+


### PR DESCRIPTION
Includes removing Rockstor `4` references from index page. We are now into the v5 release and v3 (CentOS based) is now in the distant past. Plus our downloadable installers are now also v5 based - and include the more recent Tailscale config integration.

Fixes #461

### Checklist
- [x] With the proposed changes no Sphinx errors or warnings are generated.
- [x] I have added my name to the AUTHORS file, if required (descending alphabetical order).