### PR TITLE
The requirements for the Tailscale service are not described #471

### DIFF
--- a/howtos.rst
+++ b/howtos.rst
@@ -5,6 +5,7 @@ How-tos & Guides
 .. toctree::
    :maxdepth: 2
 
+   howtos/tailscale_install
    howtos/stable_kernel_backport
    howtos/15-2_to_15-3
    howtos/15-3_to_15-4

--- a/howtos/tailscale_install.rst
+++ b/howtos/tailscale_install.rst
@@ -21,7 +21,7 @@ It is intended only to assist in providing relevant links and light guidance.
 
 .. note::
 
-    Rockstor is "Build on openSUSE", specifically **openSUSE Leap** or **Tumbleweed**: depending on the installer used.
+    Rockstor is "Built on openSUSE", specifically **openSUSE Leap** or **Tumbleweed**: depending on the installer used.
     Our Tailscale service integration requires only that a recent Tailscale instance be installed.
     The Tailscale `Stable` variant is advised but not assumed.
 

--- a/howtos/tailscale_install.rst
+++ b/howtos/tailscale_install.rst
@@ -1,0 +1,77 @@
+.. _install_tailscale:
+
+Tailscale install
+=================
+
+This How-to covers only the installation of the `Tailscale <https://tailscale.com/>`_ cloud service program.
+
+.. note::
+
+    Once installed, see our :ref:`Tailscale service <configure_tailscale>`
+    documentation for configuration and use.
+
+.. _install_tailscale_upstream:
+
+Upstream instructions
+---------------------
+
+This How-to is derived from, and secondary to,
+the canonical upstream instructions as provided by `Tailscale <https://tailscale.com/>`_ themselves.
+It is intended only to assist in providing relevant links and light guidance.
+
+.. note::
+
+    Rockstor is "Build on openSUSE", specifically **openSUSE Leap** or **Tumbleweed**: depending on the installer used.
+    Our Tailscale service integration requires only that a recent Tailscale instance be installed.
+    The Tailscale `Stable` variant is advised but not assumed.
+
+
+.. _install_tailscale_upstream_leap:
+
+Built on openSUSE Leap
+^^^^^^^^^^^^^^^^^^^^^^
+Installs derived from our Leap based `downloadable installers <https://rockstor.com/dls.html>`_.
+
+.. warning::
+
+    As of this How-to's publication, tailscale does not yet provide Leap 15.6 repositories.
+    Until Tailscale resolves this situation, consider using their 15.5 repository in the interim period.
+    Also note that their `Downloads` -> `Linux` -> `Manually install on ...` **dropdown** is
+    now years **out-of-date**. **Reference instead the following more maintained instructions.**
+
+- `Setting up Tailscale on openSUSE Leap <https://tailscale.com/kb/1303/install-opensuse-leap>`_
+
+.. note::
+
+    Replace $VERSION in the above instructions with your base OS Leap version.
+
+E.g. for Leap 15.6 (using the 15.5 repo instead):
+
+.. code-block:: console
+
+    sudo rpm --import https://pkgs.tailscale.com/stable/opensuse/leap/15.5/repo.gpg
+    sudo zypper ar -g -r https://pkgs.tailscale.com/stable/opensuse/leap/15.5/tailscale.repo
+    sudo zypper ref
+    sudo zypper in tailscale
+
+**Continue service enablement & configuration via our Web-UI** :ref:`Tailscale service <configure_tailscale>` intergration.
+
+.. _install_tailscale_upstream_tumbleweed:
+
+Built on openSUSE Tumbleweed
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Installs derived from our Tumbleweed based `downloadable installers <https://rockstor.com/dls.html>`_.
+
+- `Setting up Tailscale on openSUSE Tumbleweed <https://tailscale.com/kb/1047/install-opensuse-tumbleweed>`_
+
+E.g.
+
+.. code-block:: console
+
+    sudo rpm --import https://pkgs.tailscale.com/stable/opensuse/tumbleweed/repo.gpg
+    sudo zypper ar -g -r https://pkgs.tailscale.com/stable/opensuse/tumbleweed/tailscale.repo
+    sudo zypper ref
+    sudo zypper in tailscale
+
+**Continue service enablement & configuration via our Web-UI** :ref:`Tailscale service <configure_tailscale>` intergration.
+

--- a/interface/system/services.rst
+++ b/interface/system/services.rst
@@ -296,8 +296,15 @@ The SNMP service can now be turned ON by toggling the ON/OFF switch located to i
 Tailscale
 ---------
 
-Starting in version 5.0.5-0, Rockstor provides an easy integration of the `Tailscale <https://tailscale.com/>`_ service.
-Tailscale is a private mesh VPN using `Wireguard <https://www.wireguard.com/>`_ allowing, for instance, to connect remote machines as if they were on the same private network.
+From Rockstor version 5.0.5-0 `Tailscale <https://tailscale.com/>`_ is natively supported.
+However the required Tailscale program is intentionally **NOT pre-installed**.
+
+.. warning::
+
+    A :ref:`install_tailscale` is required before configuration or use.
+
+Tailscale is a private mesh VPN using `Wireguard <https://www.wireguard.com/>`_ allowing, for instance,
+to connect remote machines as if they were on the same private network.
 This service can thus provide an easy solution to remotely access your Rockstor instances and/or their :ref:`File sharing <accessshares>`.
 
 .. note::


### PR DESCRIPTION
Provide a new light-weight upstream instructions wrapper How-to, linked from our existing Web-UI Tailscale `service` section. And, in-turn, the How-to links back to the service section for configuration and enablement.

Fixes #471

### Checklist
- [x] With the proposed changes no Sphinx errors or warnings are generated.
- [x] I have added my name to the AUTHORS file, if required (descending alphabetical order).