### PR TITLE
Add warning on user/group ownership during pool import (#376)

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -266,10 +266,11 @@ texinfo_documents = [
 # -- Options for linkcheck ------------------------------------------------
 linkcheck_retries = 2
 linkcheck_timeout = 20
-linkcheck_ignore = [r'https://web.libera.chat/#btrfs']
-linkcheck_ignore = [r'https://ark.intel.com/']
-linkcheck_ignore = [r'https://opensource.org/license/mit-0']
-linkcheck_ignore = [r'https://opensource.org/license/apache-2-0']
+linkcheck_ignore = [r'https://web.libera.chat/#btrfs',
+                    r'https://ark.intel.com/',
+                    r'https://opensource.org/license/mit-0',
+                    r'https://opensource.org/license/apache-2-0'
+                    ]
 
 # -- Options for sphinxext.rediraffe --------------------------------------
 rediraffe_redirects = "redirects.txt"

--- a/conf.py
+++ b/conf.py
@@ -267,6 +267,9 @@ texinfo_documents = [
 linkcheck_retries = 2
 linkcheck_timeout = 20
 linkcheck_ignore = [r'https://web.libera.chat/#btrfs']
+linkcheck_ignore = [r'https://ark.intel.com/']
+linkcheck_ignore = [r'https://opensource.org/license/mit-0']
+linkcheck_ignore = [r'https://opensource.org/license/apache-2-0']
 
 # -- Options for sphinxext.rediraffe --------------------------------------
 rediraffe_redirects = "redirects.txt"

--- a/howtos/v3_to_v4.rst
+++ b/howtos/v3_to_v4.rst
@@ -191,6 +191,9 @@ So, if your prior v3 install had a customization involving a CentOS/RHEL compati
 you should now, in v4, look first for an openSUSE equivalent and then for a SLES equivalent.
 This is most likely only going to affect advanced users and is not a concern for mainly Web-UI users.
 
+
+.. _Users_default_groups:
+
 Users and default group
 ^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/interface/storage/disks.rst
+++ b/interface/storage/disks.rst
@@ -90,6 +90,17 @@ The BTRFS Pool import procedure imports the following:-
 This process is detailed in the following sub-sections: :ref:`btrfsdisk`, and
 :ref:`btrfspartition`.
 
+.. warning::
+
+   During the pool import sometimes the imported shares' ownership for user and group
+   can revert back to the default `root:root`. Before proceeding with any other
+   activities, for example a Rockstor system restore using a previously
+   generated configuration backup file, ensure that the respective share
+   user/group ownerships are set back to what they were before they were
+   imported into the Rockstor installation.
+
+
+
 ..  _btrfsdisk:
 
 Import whole disk BTRFS

--- a/interface/storage/disks.rst
+++ b/interface/storage/disks.rst
@@ -97,7 +97,8 @@ This process is detailed in the following sub-sections: :ref:`btrfsdisk`, and
    activities, for example a Rockstor system restore using a previously
    generated configuration backup file, ensure that the respective share
    user/group ownerships are set back to what they were before they were
-   imported into the Rockstor installation.
+   imported into the Rockstor installation. For how OpenSUSE handles default user
+   and group assignment see :ref:`Users_default_groups`.
 
 
 


### PR DESCRIPTION
Fixes #376

add note to check ownership of shares post pool import

### Checklist
- [X] With the proposed changes no Sphinx errors or warnings are generated.
- [X] I have added my name to the AUTHORS file, if required (descending alphabetical order).