### PR TITLE
Tailscale install how-to needs to be updated for Leap 15.6 #512

### DIFF
--- a/howtos/tailscale_install.rst
+++ b/howtos/tailscale_install.rst
@@ -16,62 +16,40 @@ Upstream instructions
 ---------------------
 
 This How-to is derived from, and secondary to,
-the canonical upstream instructions as provided by `Tailscale <https://tailscale.com/>`_ themselves.
+the canonical upstream instructions as provided by Tailscale themselves.
 It is intended only to assist in providing relevant links and light guidance.
 
 .. note::
 
-    Rockstor is "Built on openSUSE", specifically **openSUSE Leap** or **Tumbleweed**: depending on the installer used.
-    Our Tailscale service integration requires only that a recent Tailscale instance be installed.
+    Rockstor is "Built on openSUSE", specifically **openSUSE Leap** or **Tumbleweed**:
+    depending on the `downloadable installer <https://rockstor.com/dls.html>`_ used.
+    *Our Tailscale service integration requires only that a relevant Tailscale repo and package be installed.*
     The Tailscale `Stable` variant is advised but not assumed.
 
 
-.. _install_tailscale_upstream_leap:
+.. _install_tailscale_upstream_openSUSE:
 
-Built on openSUSE Leap
-^^^^^^^^^^^^^^^^^^^^^^
-Installs derived from our Leap based `downloadable installers <https://rockstor.com/dls.html>`_.
+Install Tailscale repo and package
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-.. warning::
+From the `Tailscale <https://tailscale.com/>`_ website select:
 
-    As of this How-to's publication, tailscale does not yet provide Leap 15.6 repositories.
-    Until Tailscale resolves this situation, consider using their 15.5 repository in the interim period.
-    Also note that their `Downloads` -> `Linux` -> `Manually install on ...` **dropdown** is
-    now years **out-of-date**. **Reference instead the following more maintained instructions.**
-
-- `Setting up Tailscale on openSUSE Leap <https://tailscale.com/kb/1303/install-opensuse-leap>`_
+- `Downloads` -> `Linux`
+- Scroll down to the **Manually install on** selector and choose your "Build on **openSUSE**" version.
 
 .. note::
 
-    Replace $VERSION in the above instructions with your base OS Leap version.
+    Only steps 1 and 2 are required, Rockstor's Web-UI can do the rest.
 
-E.g. for Leap 15.6 (using the 15.5 repo instead):
-
-.. code-block:: console
-
-    sudo rpm --import https://pkgs.tailscale.com/stable/opensuse/leap/15.5/repo.gpg
-    sudo zypper ar -g -r https://pkgs.tailscale.com/stable/opensuse/leap/15.5/tailscale.repo
-    sudo zypper ref
-    sudo zypper in tailscale
-
-**Continue service enablement & configuration via our Web-UI** :ref:`Tailscale service <configure_tailscale>` intergration.
-
-.. _install_tailscale_upstream_tumbleweed:
-
-Built on openSUSE Tumbleweed
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Installs derived from our Tumbleweed based `downloadable installers <https://rockstor.com/dls.html>`_.
-
-- `Setting up Tailscale on openSUSE Tumbleweed <https://tailscale.com/kb/1047/install-opensuse-tumbleweed>`_
-
-E.g.
+E.g. for "Build on **openSUSE**" **Leap 15.6** you need only do the following at the command line interface:
 
 .. code-block:: console
 
-    sudo rpm --import https://pkgs.tailscale.com/stable/opensuse/tumbleweed/repo.gpg
-    sudo zypper ar -g -r https://pkgs.tailscale.com/stable/opensuse/tumbleweed/tailscale.repo
+    sudo rpm --import https://pkgs.tailscale.com/stable/opensuse/leap/15.6/repo.gpg
+    sudo zypper ar -g -r https://pkgs.tailscale.com/stable/opensuse/leap/15.6/tailscale.repo
     sudo zypper ref
     sudo zypper in tailscale
 
-**Continue service enablement & configuration via our Web-UI** :ref:`Tailscale service <configure_tailscale>` intergration.
+**Continue service enablement & configuration via our Web-UI** :ref:`Tailscale service <configure_tailscale>` integration.
+
 


### PR DESCRIPTION
### This pull request's proposal

Removes warnings re no upstream 15.6 repo availability and provisos re outdated upstream documentation. We now have full 15.6 and TW instructions available from upstream Downloads -> Linux. As such we now reference those and remove our redundancy re Tumbleweed specific instructions.

Includes minor re-wording, redundant upstream link removal, and simplification: removing deep upstream url links.

Fixes #512 

### Checklist
- [x] With the proposed changes no Sphinx errors or warnings are generated.
- [x] I have added my name to the AUTHORS file, if required (descending alphabetical order).

---

Proviso we have changed an internal link here re:

.. _install_tailscale_upstream_leap:
.. _install_tailscale_upstream_openSUSE:

We have not been notified of any official use of this internal sub-header link and our overall page url remains unchanged by this proposal.
