### PR TITLE
Change the Copyright Year to 2025

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -15,6 +15,7 @@ Mirko Arena
 Mazo
 lifton
 Jon Wilson
+Javed Ali
 Hooverdan96
 HBDK
 Gompa

--- a/themes/rockstor/layout.html
+++ b/themes/rockstor/layout.html
@@ -114,7 +114,7 @@
         <div id="footer">
             <div class="row-fluid">
                 <div id="footer-links" class="span12 centertext">
-                    Copyright &copy; 2024 The Rockstor Project.&nbsp;
+                    Copyright &copy; 2025 The Rockstor Project.&nbsp;
                     <a rel="license"
                        href="https://creativecommons.org/licenses/by-sa/4.0/"><img
                         alt="Creative Commons Licence" style="border-width:0"


### PR DESCRIPTION
> To ease and accelerate the PR submission, please use the template below to provide all required information.
> Please see our "Contributing to Rockstor documentation" in our [Rockstor's documentation](http://rockstor.com/docs/contribute_documentation.html)

Fixes #
Changed the Copyright Year to 2025
### This pull request's proposal
Changing of Copyright year to 2025

### Checklist
- [x] With the proposed changes no Sphinx errors or warnings are generated.
- [x] I have added my name to the AUTHORS file, if required (descending alphabetical order).