### PR TITLE
Sphinx linkcheck step -rate limited- #527

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -265,11 +265,13 @@ texinfo_documents = [
 
 # -- Options for linkcheck ------------------------------------------------
 linkcheck_retries = 2
-linkcheck_timeout = 20
+linkcheck_timeout = 10
 linkcheck_ignore = [r'https://web.libera.chat/#btrfs',
                     r'https://ark.intel.com/',
-                    r'https://opensource.org/license/mit-0',
-                    r'https://opensource.org/license/apache-2-0'
+                    r'https://opensource.org/',
+                    r'https://www.samba.org/',
+                    r'https://www.gnu.org/',
+                    r'https://github.com/'
                     ]
 
 # -- Options for sphinxext.rediraffe --------------------------------------

--- a/contribute/contribute_documentation.rst
+++ b/contribute/contribute_documentation.rst
@@ -7,7 +7,7 @@ Steps for contributing to **rockstor-doc** repo are similar to contributing to
 **rockstor-core**, as we follow the same fork and pull request model. We'll
 assume you have basic proficiency with Git and are familiar with using a
 text editor or IDE of your choice. Emacs, Vim, Eclipse and PyCharm are some
-recommendations. Or you may be able to use an online editor such as https://www.tutorialspoint.com/online_restructure_editor.php.
+recommendations. Or you may be able to use an online editor such as https://www.tutorialspoint.com/compilers/online-restructure-editor.htm.
 
 Environment setup
 -----------------

--- a/interface/docker-based-rock-ons/nginx.rst
+++ b/interface/docker-based-rock-ons/nginx.rst
@@ -38,10 +38,7 @@ The sources and documentation are distributed under the 2-clause BSD-like licens
 nginx Documentation
 --------------------
 
-For online documentation and support please refer to `nginx.org <https://nginx.org>`_. Commercial support is available from `F5, Inc. <https://www.f5.com/>`_.
-
-Also, check out youtube for instructional videos on `Nginx <https://www.youtube.com/user/nginxinc>`_.
-
+For online documentation and support please refer to `nginx.org <https://nginx.org>`_.
 
 
 .. _nginx_install:

--- a/interface/overview.rst
+++ b/interface/overview.rst
@@ -170,7 +170,7 @@ instructions they are like all Rock-on installs, fairly self explanatory.
 
 * `Booksonic <https://booksonic.org>`_: Audiobooks streaming server
 * `Cardigann <https://github.com/cardigann/cardigann>`_: A proxy server for adding new indexers to Sonarr and other media managers
-* `Collabora online <https://www.collaboraoffice.com/code/>`_: LibreOffice-based online office suite
+* `Collabora online <https://www.collaboraonline.com/code/>`_: LibreOffice-based online office suite
 * `COPS <https://blog.slucas.fr/projects/calibre-opds-php-server/>`_: links to your Calibre library database and provides automation features
 * `CouchPotato <https://couchpota.to/>`_: Downloader for usenet and bittorrent users
 * `Deluge <https://deluge-torrent.org/>`_: Deluge is a movie downloader for bittorrent users
@@ -192,7 +192,7 @@ instructions they are like all Rock-on installs, fairly self explanatory.
 * `Koel <https://koel.dev/>`_: Simple web-based personal audio streaming service
 * `Lazy Librarian <https://lazylibrarian.gitlab.io>`_: Automated ebook downloader for NZB and Torrent
 * `MariaDB <https://mariadb.org/>`_: MariaDB, relational database management system
-* `Medusa <https://pymedusa.com>`_: Automatic video library manager for TV shows
+* `Medusa <https://github.com/pymedusa/Medusa>`_: Automatic video library manager for TV shows
 * `Minecraft <https://en.wikipedia.org/wiki/Minecraft>`_: Minecraft server
 * `Muximux <https://github.com/mescon/Muximux>`_: Lightweight portal to view & manage your HTPC apps
 * `Mylar <https://github.com/evilhero/mylar>`_: Automated Comic Book (cbr/cbz) downloader


### PR DESCRIPTION
### This pull request's proposal

Rationalise existing linkcheck excludes down to
domain only, adding a number of newer domains that are now rate-limiting.

Includes a number of link edits/updates or extraneous removals in the interest of backing away from becoming a link farm. We also avoid using YouTube links if possible.

Reduce linkcheck_timeout from 20 to 10 seconds.

Fixes #527


### Checklist
- [x] With the proposed changes no Sphinx errors or warnings are generated.
- [x] I have added my name to the AUTHORS file, if required (descending alphabetical order).