### PR TITLE
Update 15.4-15.5 & 15.5-15.6 how-tos re version compatibility #511

### DIFF
--- a/howtos/15-4_to_15-5.rst
+++ b/howtos/15-4_to_15-5.rst
@@ -9,7 +9,7 @@ to the next major version of our base OS.
 Only one major version jump must be attempted at any one time.
 If your Rockstor install is not based on 15.4, consider one of our other "Distribution update ..." How-tos.
 
-- **A minimum Rockstor version of 5.0.9-0 is recommended before attempting this OS update.**
+- **A minimum Rockstor version of 4.6.1-0 (stable) or 5.0.15-0 (testing) is recommended before attempting this OS update.**
 
 .. note::
 

--- a/howtos/15-5_to_15-6.rst
+++ b/howtos/15-5_to_15-6.rst
@@ -9,7 +9,8 @@ to the next major version of our base OS.
 Only one major version jump must be attempted at any one time.
 If your Rockstor install is not based on 15.5, consider one of our other "Distribution update ..." How-tos.
 
-- **A minimum Rockstor version of 5.0.9-0 is recommended before attempting this OS update.**
+- **A Rockstor version of 5.0.15-0 (testing) is recommended before attempting this OS update.**
+- **Stable users are advised to await the imminent publication of 5.1.0-0 to stable also on 15.6.**
 
 .. note::
 


### PR DESCRIPTION
Update minimum recommended versions to indicate last released in each of testing & stable: 15.4-15.5.

For 15.5-15.6 we update the testing version only until version 5.1.0-0 is published for stable as well as testing on 15.6. Adding a note to this effect on the 15.5-15.6 guide.

Fixes #511

### Checklist
- [x] With the proposed changes no Sphinx errors or warnings are generated.
- [x] I have added my name to the AUTHORS file, if required (descending alphabetical order).