### PR TITLE
smartmontools.org linkcheck failures #533

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -269,6 +269,7 @@ linkcheck_timeout = 10
 # www.smartmontools.org is a temporary exclusion
 linkcheck_ignore = [r'https://web.libera.chat/#btrfs',
                     r'https://www.smartmontools.org',
+                    r'https://linux.die.net/',
                     r'https://ark.intel.com/',
                     r'https://opensource.org/',
                     r'https://www.samba.org/',

--- a/conf.py
+++ b/conf.py
@@ -266,7 +266,9 @@ texinfo_documents = [
 # -- Options for linkcheck ------------------------------------------------
 linkcheck_retries = 2
 linkcheck_timeout = 10
+# www.smartmontools.org is a temporary exclusion
 linkcheck_ignore = [r'https://web.libera.chat/#btrfs',
+                    r'https://www.smartmontools.org',
                     r'https://ark.intel.com/',
                     r'https://opensource.org/',
                     r'https://www.samba.org/',

--- a/howtos/smart.rst
+++ b/howtos/smart.rst
@@ -93,7 +93,7 @@ In the tooltip a few more directives of interest are listed:
   
 For a complete explanation of all directives read the *smartd.conf* man page, also
 available here:
-`smartd.conf man page <https://www.smartmontools.org/browser/trunk/smartmontools/smartd.conf.5.in>`_
+`smartd.conf man page <https://linux.die.net/man/5/smartd.conf>`_
 
 ..  _diskcustomsmart:
 
@@ -188,7 +188,7 @@ The research links contained within the configuration screen are duplicated
 here for convenience:
 
 * Main `Smartmontools <https://www.smartmontools.org/>`_ home page.
-* *Smartmontools* `manual <https://www.smartmontools.org/browser/trunk/smartmontools/smartctl.8.in>`_ for the the smartctl program.
+* *Smartmontools* `manual <https://linux.die.net/man/8/smartctl>`_ for the smartctl program.
 * `USB Device Support <https://www.smartmontools.org/wiki/Supported_USB-Devices>`_ note the *Options* column in the *Supported Devices* table.
 * `Checking disks behind RAID controllers <https://www.smartmontools.org/wiki/Supported_RAID-Controllers>`_ page.
 


### PR DESCRIPTION
Fixes #533

### This pull request's proposal

Temporarily use alternative URLs for 2 key manual page links. Add domain to linkcheck_ignore config, with a proviso that this be temporary.

Smartmontools the project, looks to be undergoing a large migration from their long time host of
Sourceforge (SVN) to GitHub (git). It is assumed
that the website difficulties are related to this
move.


### Checklist
- [x] With the proposed changes no Sphinx errors or warnings are generated.
- [x] I have added my name to the AUTHORS file, if required (descending alphabetical order).