### PR TITLE
Add repo public key update step to 15.5 to 15.6 howto #538

### DIFF
--- a/howtos/15-5_to_15-6.rst
+++ b/howtos/15-5_to_15-6.rst
@@ -40,11 +40,25 @@ Overview
 This **Distribution Update** procedure is well established in our upstream base OS of openSUSE Leap.
 Below we detail the following steps, each in their own sections:
 
+- Update Rockstor's public key
 - Update repositories
 - Distribution update
 - Reporting issues
 
 See our FAQ entry :ref:`faq_rockstor4_repos` for more context.
+
+.. _155_156-update_repo_key:
+
+Update Rockstor's public key
+----------------------------
+
+Rockstor's repo and rpm package signing key was expiration extended in May 2025.
+Ensure the latest version is installed via:
+
+.. code-block:: console
+
+    rpm --erase gpg-pubkey-5f043187
+    rpm --import https://rockstor.com/ROCKSTOR-GPG-KEY
 
 .. _155_156-update_repos:
 


### PR DESCRIPTION
Fixes #538

### This pull request's proposal

Avoids "The gpg key signing file 'repomd.xml' has expired" during the zypper refresh command instructed later in this howto.

### Checklist
- [x] With the proposed changes no Sphinx errors or warnings are generated.
- [x] I have added my name to the AUTHORS file, if required (descending alphabetical order).