### PR TITLE
Update Stable notice re 15.5-15.6 how-to #540

### DIFF
--- a/howtos/15-5_to_15-6.rst
+++ b/howtos/15-5_to_15-6.rst
@@ -9,8 +9,7 @@ to the next major version of our base OS.
 Only one major version jump must be attempted at any one time.
 If your Rockstor install is not based on 15.5, consider one of our other "Distribution update ..." How-tos.
 
-- **A Rockstor version of 5.0.15-0 (testing) is recommended before attempting this OS update.**
-- **Stable users are advised to await the imminent publication of 5.1.0-0 to stable also on 15.6.**
+- **A minimum Rockstor version of 4.6.1-0 (stable) or 5.0.15-0 (testing) is recommended before attempting this OS update.**
 
 .. note::
 


### PR DESCRIPTION
Fixes #540

### This pull request's proposal

As v5.1.0-0 is now available also in the stable channel, we can adopt the same advice as was presented in our 15.4-15.5 how-to. Only this time the OS distribution update will now also include the 'rockstor' pkg update to 5.1.0-0 which is only compatible with the how-to target of Leap 15.6.

### Checklist
- [x] With the proposed changes no Sphinx errors or warnings are generated.
- [x] I have added my name to the AUTHORS file, if required (descending alphabetical order).