### PR TITLE
Add arm64 target build re repo container #562

### DIFF
--- a/.github/workflows/deploy-image.yml
+++ b/.github/workflows/deploy-image.yml
@@ -31,10 +31,17 @@ jobs:
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
       -
+        name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      -
         name: Build and push Docker image
         uses: docker/build-push-action@v6
         with:
           context: ./docker/
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
Fixes #562

### This pull request's proposal

Add arm64 as a target architecture: deploy-image.yml. In keeping with our ongoing aims to support both
amd64 & arm64 within our supported OSs and our Rock-ons.

### Checklist
- [x] With the proposed changes no Sphinx errors or warnings are generated.
- [x] I have added my name to the AUTHORS file, if required (descending alphabetical order).