### PR TITLE
Zoneminder doc has a broken link #570

### DIFF
--- a/interface/docker-based-rock-ons/zoneminder.rst
+++ b/interface/docker-based-rock-ons/zoneminder.rst
@@ -182,7 +182,7 @@ Reproduced here for clarity:
 
    Important:
 
-   The web gui will be available at http://serverip:port/zm.
+   The WebUI will be available at :code:`http://serverip:port/zm`.
    On first start, open zoneminder options, go to the Paths tab and enter the following for PATH_ZMS: /zm/cgi-bin/nph-zms.
 
    The default timezone for php is set as America/New_York if you would like to change it, edit the php.ini in the config folder.


### PR DESCRIPTION
Fixes #570

### This pull request's proposal

Code comment an explanatory URL that is, in more modern Sphinx, picked up as a real URL and so fails `make linkcheck`.

### Checklist
- [x] With the proposed changes no Sphinx errors or warnings are generated.
- [x] I have added my name to the AUTHORS file, if required (descending alphabetical order).