### PR TITLE
grafana-cloud linkcheck error #578

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -269,6 +269,7 @@ linkcheck_timeout = 10
 # www.smartmontools.org is a temporary exclusion
 linkcheck_ignore = [r'https://web.libera.chat/#btrfs',
                     r'https://www.smartmontools.org',
+                    r'https://www.freedesktop.org',
                     r'https://www.virtualbox.org',
                     r'https://linux.die.net/',
                     r'https://ark.intel.com/',


### PR DESCRIPTION
Add the relevant domain to our linkcheck_ignore list in conf.py, as this domain appears to defend against machine orientated link-checking so we should back-off from trying.

Fixes #578 
