### PR TITLE
Update Bareos Rockon guide re Leap 16.0 #597

### DIFF
--- a/interface/docker-based-rock-ons/bareos-backup-server.rst
+++ b/interface/docker-based-rock-ons/bareos-backup-server.rst
@@ -318,11 +318,11 @@ As does the bconsole command ``*status director``.
 - Minimal install package name: **bareos-filedaemon**
 - Desktop / Laptop package name: **bareos-client** (includes: bareos-filedaemon, bareos-bconsole, and bareos-traymonitor)
 
-E.g. openSUSE Leap 15.6 Desktop/Laptop (community, current assumed) :
+E.g. on an openSUSE Leap 16.0/16.1 Desktop/Laptop (community repository, current channel):
 
 .. code-block:: bash
 
-    wget https://download.bareos.org/current/SUSE_15/add_bareos_repositories.sh
+    wget https://download.bareos.org/current/SUSE_16/add_bareos_repositories.sh
     sh ./add_bareos_repositories.sh
     zypper refresh
     zypper install bareos-client


### PR DESCRIPTION
Fixes #597

### This pull request's proposal

Move example client install from Leap 15.6 to Leap 16.0/16.1. Includes minor rewording.


### Checklist
- [x] With the proposed changes no Sphinx errors or warnings are generated.
- [x] I have added my name to the AUTHORS file, if required (descending alphabetical order).